### PR TITLE
fix(cli): normalize --depends-on to zero-padded 3-digit IDs (T267)

### DIFF
--- a/skills/cmux-team/manager/main.ts
+++ b/skills/cmux-team/manager/main.ts
@@ -39,7 +39,7 @@ import { start as startProxy } from "./proxy";
 import { launchConductor, resetConductor } from "./conductor";
 import { createHash } from "crypto";
 import { initDB, insertTaskSession, getSessionsForTask, getTaskSessions, getHookSignals, type HookSignalRecord } from "./trace-store";
-import { loadTaskState, loadTasks, saveTaskState, createTaskProgrammatic, cascadeAbortToChildren, detectStartupUniqueViolations, classifyResumeAction, buildResumeAbortJournal, markTaskAborted, parseAbortJournal, type TaskState, type TaskMeta } from "./task";
+import { loadTaskState, loadTasks, saveTaskState, createTaskProgrammatic, cascadeAbortToChildren, detectStartupUniqueViolations, classifyResumeAction, buildResumeAbortJournal, markTaskAborted, parseAbortJournal, normalizeTaskIdList, type TaskState, type TaskMeta } from "./task";
 import { loadArtifacts, searchArtifacts, validateArtifact, addArtifact } from "./artifact";
 import { runPreflight, printPreflightIssues } from "./preflight";
 import { acquireOrExit, releasePidFile } from "./pidfile";
@@ -2853,9 +2853,13 @@ async function cmdCreateTask(): Promise<void> {
     phase: "create",
   });
 
-  const dependsOn = dependsOnRaw
-    ? dependsOnRaw.split(",").map(s => s.trim()).filter(Boolean)
-    : [];
+  let dependsOn: string[];
+  try {
+    dependsOn = normalizeTaskIdList(dependsOnRaw);
+  } catch (e: any) {
+    console.error(`Error: ${e.message}`);
+    process.exit(1);
+  }
 
   let result: { id: string; filePath: string; relPath: string };
   try {
@@ -2944,9 +2948,13 @@ async function cmdUpdateTask(): Promise<void> {
 
   // --depends-on: frontmatter 内の depends_on 行を更新（なければ追加）
   if (dependsOn !== undefined) {
-    const depsArray = dependsOn
-      ? dependsOn.split(",").map(s => s.trim()).filter(Boolean)
-      : [];
+    let depsArray: string[];
+    try {
+      depsArray = normalizeTaskIdList(dependsOn);
+    } catch (e: any) {
+      console.error(`Error: ${e.message}`);
+      process.exit(1);
+    }
     const depsValue = depsArray.length > 0 ? `[${depsArray.join(", ")}]` : "[]";
     let content = await readFile(taskFile, "utf-8");
     if (content.match(/^depends_on:\s*.+$/m)) {

--- a/skills/cmux-team/manager/task.test.ts
+++ b/skills/cmux-team/manager/task.test.ts
@@ -13,6 +13,8 @@ import {
   parseAbortJournal,
   saveTaskState,
   loadTaskState,
+  normalizeTaskId,
+  normalizeTaskIdList,
 } from "./task";
 import type { TaskMeta, TaskState, TaskStateMap } from "./task";
 
@@ -110,6 +112,154 @@ status: ready
 `;
     const meta = parseTaskMeta(content, "042-no-id.md", "/path/042-no-id.md");
     expect(meta!.id).toBe("042");
+  });
+});
+
+describe("normalizeTaskId (T267)", () => {
+  // 正常系
+  test("1 桁をゼロパディング: '1' → '001'", () => {
+    expect(normalizeTaskId("1")).toBe("001");
+  });
+
+  test("2 桁をゼロパディング: '28' → '028'", () => {
+    expect(normalizeTaskId("28")).toBe("028");
+  });
+
+  test("3 桁はそのまま: '028' → '028'", () => {
+    expect(normalizeTaskId("028")).toBe("028");
+  });
+
+  test("3 桁ゼロパディングなし: '100' → '100'", () => {
+    expect(normalizeTaskId("100")).toBe("100");
+  });
+
+  test("4 桁以上はそのまま: '1000' → '1000'", () => {
+    expect(normalizeTaskId("1000")).toBe("1000");
+  });
+
+  test("前後空白を trim: ' 28 ' → '028'", () => {
+    expect(normalizeTaskId(" 28 ")).toBe("028");
+  });
+
+  // 異常系
+  test("英字は throw: 'abc'", () => {
+    expect(() => normalizeTaskId("abc")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "abc"',
+    );
+  });
+
+  test("英数混在は throw: '28a'", () => {
+    expect(() => normalizeTaskId("28a")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "28a"',
+    );
+  });
+
+  test("小数は throw: '1.5'", () => {
+    expect(() => normalizeTaskId("1.5")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "1.5"',
+    );
+  });
+
+  test("負数は throw: '-1'", () => {
+    expect(() => normalizeTaskId("-1")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "-1"',
+    );
+  });
+
+  test("+ 符号は throw: '+1'", () => {
+    expect(() => normalizeTaskId("+1")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "+1"',
+    );
+  });
+
+  test("16 進は throw: '0x10'", () => {
+    expect(() => normalizeTaskId("0x10")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "0x10"',
+    );
+  });
+
+  test("指数表記は throw: '1e2'", () => {
+    expect(() => normalizeTaskId("1e2")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "1e2"',
+    );
+  });
+
+  test("ゼロは throw: '0'（task ID は 1 始まり規約）", () => {
+    expect(() => normalizeTaskId("0")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "0"',
+    );
+  });
+
+  test("ゼロパディングゼロは throw: '000'", () => {
+    expect(() => normalizeTaskId("000")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "000"',
+    );
+  });
+
+  test("空文字は throw: ''", () => {
+    expect(() => normalizeTaskId("")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: ""',
+    );
+  });
+
+  test("空白のみは throw: '   '", () => {
+    expect(() => normalizeTaskId("   ")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "   "',
+    );
+  });
+});
+
+describe("normalizeTaskIdList (T267)", () => {
+  // 正常系
+  test("空文字は空配列: '' → []", () => {
+    expect(normalizeTaskIdList("")).toEqual([]);
+  });
+
+  test("単一: '28' → ['028']", () => {
+    expect(normalizeTaskIdList("28")).toEqual(["028"]);
+  });
+
+  test("複数混在: '001,28,100' → ['001', '028', '100']", () => {
+    expect(normalizeTaskIdList("001,28,100")).toEqual(["001", "028", "100"]);
+  });
+
+  test("前後空白: ' 28 , 100 ' → ['028', '100']", () => {
+    expect(normalizeTaskIdList(" 28 , 100 ")).toEqual(["028", "100"]);
+  });
+
+  test("空要素 skip: '001,,028' → ['001', '028']", () => {
+    expect(normalizeTaskIdList("001,,028")).toEqual(["001", "028"]);
+  });
+
+  test("末尾カンマ: '28,' → ['028']", () => {
+    expect(normalizeTaskIdList("28,")).toEqual(["028"]);
+  });
+
+  test("カンマのみ: ',,' → []", () => {
+    expect(normalizeTaskIdList(",,")).toEqual([]);
+  });
+
+  test("重複は保持する（dedup しない）: '28,028' → ['028', '028']", () => {
+    expect(normalizeTaskIdList("28,028")).toEqual(["028", "028"]);
+  });
+
+  // 異常系
+  test("いずれかが invalid は throw: '001,abc' → Got: 'abc'", () => {
+    expect(() => normalizeTaskIdList("001,abc")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "abc"',
+    );
+  });
+
+  test("最初が invalid は最初の invalid を報告: 'abc,001' → Got: 'abc'", () => {
+    expect(() => normalizeTaskIdList("abc,001")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "abc"',
+    );
+  });
+
+  test("ゼロ混在は throw: '001,0' → Got: '0'", () => {
+    expect(() => normalizeTaskIdList("001,0")).toThrow(
+      '--depends-on must be positive integer task IDs. Got: "0"',
+    );
   });
 });
 

--- a/skills/cmux-team/manager/task.ts
+++ b/skills/cmux-team/manager/task.ts
@@ -202,6 +202,49 @@ export function buildResumeAbortJournal(
 }
 
 /**
+ * T267: タスク ID を 3 桁ゼロパディングへ正規化する。
+ *
+ * 新規 ID は `createTaskProgrammatic` が `String(n).padStart(3, "0")` で発行するため、
+ * CLI 経由の `--depends-on` も同一形式へ揃えないと frontmatter の `depends_on` が
+ * `closedIds.has(...)` 比較で取りこぼされる（issue #25）。
+ *
+ * - 10 進整数文字列のみ受け付ける（`0x10` / `1.5` / `-1` / `+1` / `1e2` は reject）
+ * - `1` 以上を要求（`0` / `000` は reject — 新規 ID は 1 始まり）
+ * - 4 桁以上はそのまま（`padStart` の minLength 仕様と一致）
+ */
+export function normalizeTaskId(raw: string): string {
+  const s = raw.trim();
+  if (!/^\d+$/.test(s)) {
+    throw new Error(
+      `--depends-on must be positive integer task IDs. Got: "${raw}"`,
+    );
+  }
+  const n = parseInt(s, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    throw new Error(
+      `--depends-on must be positive integer task IDs. Got: "${raw}"`,
+    );
+  }
+  return String(n).padStart(3, "0");
+}
+
+/**
+ * T267: カンマ区切りのタスク ID 文字列を正規化済み配列へ変換する。
+ *
+ * - 空文字・カンマのみ・末尾カンマは `[]` を返す（update-task の「依存クリア」経路を維持）
+ * - 順序・重複はそのまま保持（dedup しない）
+ * - いずれか 1 要素でも invalid なら最初の invalid で throw
+ */
+export function normalizeTaskIdList(raw: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(normalizeTaskId);
+}
+
+/**
  * YAML frontmatter からメタデータを抽出
  */
 export function parseTaskMeta(content: string, fileName: string, filePath: string): TaskMeta | null {


### PR DESCRIPTION
## Summary

Closes #25.

`cmux-team create-task --depends-on 28` のような非ゼロパディング ID を渡すと依存が永遠に解決されないサイレント失敗を解消する。CLI 入口で `--depends-on` を 3 桁ゼロパディングに正規化するヘルパーを追加し、create-task / update-task 両方の経路で通すようにした。

## 変更内容

- `skills/cmux-team/manager/task.ts`: `normalizeTaskId` / `normalizeTaskIdList` を追加・export
- `skills/cmux-team/manager/main.ts`: create-task / update-task の `--depends-on` を `normalizeTaskIdList` 経由に変更
- `skills/cmux-team/manager/task.test.ts`: 28 テストケース追加（正常 14 / 異常 14）

### 入力仕様

- 正の整数のみ受理（`/^\d+$/` + `n >= 1`）
- `28` → `"028"`、`028` → `"028"`、`001,28,100` → `["001","028","100"]`
- `0` / `000` は reject
- 空文字全体は `[]`（依存クリア経路を維持）
- 重複は保持（dedup しない）

### エラー挙動

不正入力（`abc` / `-1` / `1.5` / `0x10` / `000` など）:

```
Error: --depends-on must be positive integer task IDs. Got: "abc"
```

stderr に出力して exit 1。

## Test plan

- [x] `bun test skills/cmux-team/manager/` — 625 pass / 0 fail（追加 28 件含む）
- [x] 手動検証: `cmux-team create-task --depends-on 28` で `depends_on: [028]` に正規化される
- [x] 手動検証: `cmux-team create-task --depends-on abc` で exit 1 + stderr エラーメッセージ
- [x] 手動検証: `cmux-team update-task --depends-on ""` で依存クリア（`depends_on: []`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)