### PR TITLE
feat(gh-cache): GitHub issue/PR cache (daemon-managed, SQLite, CLI, TUI Issues tab) — T272

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 .team/logs/
 .team/queue/
 .team/e2e-results/
+.team/gh-cache.db
+.team/gh-cache.db-wal
+.team/gh-cache.db-shm
 .worktrees/
 .claude/worktrees/
 .claude/scheduled_tasks.lock

--- a/.team/tasks/272-github-issue-pr-daemon-sqlite-cli-tui-issues/runs/task-272-1776622205/impl-report.md
+++ b/.team/tasks/272-github-issue-pr-daemon-sqlite-cli-tui-issues/runs/task-272-1776622205/impl-report.md
@@ -1,0 +1,190 @@
+---
+id: impl-report
+task: T272
+run: task-272-1776622205
+branch: task-272-1776622205/task
+base: main
+commits:
+  - 1a86ab5 Phase 1 — DB schema + REST ETag sync + cmdGh
+  - ce243e6 Phase 2 — CLI issue/pr list/show/search
+  - b51a437 Phase 3 — TUI Issues タブ
+  - 4b57a54 Phase 4 — Claude Code 誘導スキル cmux-team-gh
+---
+
+# T272 Implementation Report
+
+## 概要
+
+GitHub issue / PR の読み取りを SQLite キャッシュ経由に置き換え、`cmux-team`
+plugin から `gh` を叩かずに issue / PR を参照できるようにした。差分同期
+（ETag + since）により rate limit を消費せず、複数エージェントが同一
+issue を繰り返し参照するユースケースでコストが 0 になる。
+
+plan.md（Phase 1 〜 4）に従い、段階的に 4 commit で実装した。
+
+## Phase 別の成果
+
+### Phase 1 (commit 1a86ab5) — DB スキーマ + REST ETag sync + `cmdGh`
+
+- `gh-cache-types.ts` — `RepoInfo` / `IssueRow` / `LabelRow` / `CommentRow` /
+  `ReviewRow` / `ReviewCommentRow` / `SyncMeta` / `AuthResolution` 等 zod
+  スキーマ付き型定義
+- `gh-cache-repo.ts` — `resolveOriginRepo(projectRoot)` で `git remote get-url
+  origin` を解釈し `host/owner/repo` を返す。非 GitHub / 非 git は `null`
+- `gh-cache-auth.ts` — `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` を
+  順に試す。失敗時は `checked` 配列で可視化。`tokenHash(token)` で
+  SHA-256 先頭 12 文字を返し DB に保存して purge 判定に使う
+- `gh-cache-store.ts` — SQLite WAL + PRAGMA foreign_keys=ON。`sync_meta` /
+  `issues` / `labels` / `assignees` / `issue_labels` / `issue_assignees` /
+  `issue_comments` / `pr_reviews` / `pr_review_comments` の 9 テーブル。
+  トークン/repo 不一致で自動 purge
+- `gh-cache-sync.ts` — `syncFull` / `syncIncremental` で REST v3 を叩く。
+  `If-None-Match` + `since=` で差分のみ取得、304 は rate limit 消費 0。
+  `RateLimitExhaustedError` / `SyncHttpError` を個別に投げる
+- `main.ts` `cmdGh()` — `gh sync [--full]` / `gh status` を実装。
+  exit code 0/1/2/3/4 を plan 通り
+- i18n: `gh_*` キーを英日両方に追加
+
+テスト: `gh-cache-repo.test.ts` / `gh-cache-auth.test.ts` /
+`gh-cache-store.test.ts` / `gh-cache-sync.test.ts`（計 60+ 件）。
+`fetchFn` DI でネットワーク経路を完全に stub 化。
+
+### Phase 2 (commit ce243e6) — CLI `issue` / `pr` サブコマンド
+
+- `gh-cache-format.ts` — gh-compat JSON フォーマッタ
+  - `toGhJson(rel)` — `state` 大文字化 (`OPEN` / `CLOSED` / `MERGED`),
+    `author.login` / `assignees[].login` / `labels[].name` /
+    camelCase dates (`createdAt`, `updatedAt`, `closedAt`, `mergedAt`)
+  - `normalizeGhState(issue)` — PR + `merged_at` なら `MERGED`
+  - `pickGhFields(source, fields[])` — `gh --json FIELDS` 互換。
+    ドットパス (`author.login`) と配列マップ (`assignees[].login`) をサポート
+  - `formatIssueListRow` / `formatIssueShow` — 人間向け text 出力
+  - `displayState(issue)` — 小文字版 (`open` / `closed` / `merged`)
+- `gh-cache-cli.ts` — `cmdIssueList` / `cmdPrList` / `cmdIssueShow` /
+  `cmdIssueSearch`
+  - `--state open|closed|merged|all`, `--assignee`, `--author`, `--label`,
+    `--limit`, `--json FIELDS`, `--sync`, `--stale-ok` をサポート
+  - `@me` は `sync_meta.viewer_login` から解決（未キャッシュなら exit 1 +
+    ガイダンス）
+  - `STALE_DAYS=7` を超えると警告（`--stale-ok` で抑止）
+  - `CliDeps` パターンで `stdout` / `fetchFn` を DI 可能に
+- `main.ts` に `cmdIssue()` / `cmdPr()` を追加し switch-case で振り分け
+
+テスト: `gh-cache-format.test.ts` (20 件) / `gh-cache-cli.test.ts`
+(23 件)。`process.exit` を monkey-patch して exit code を assert。
+
+end-to-end 検証 (`.team/gh-cache.db` with real data):
+
+```
+$ bun main.ts issue list
+  #26  open     task-272 の daemon 再起動時の resume バグ ...
+  ...
+$ bun main.ts issue list --assignee @me
+  (viewer_login=hummer98 で正しく解決)
+$ bun main.ts issue list --json "number,title,author.login,assignees[].login"
+  [{"number":26,"title":"...","author":"...","assignees":["hummer98"]},...]
+```
+
+### Phase 3 (commit b51a437) — TUI Issues タブ
+
+- `dashboard.tsx`
+  - `AppState` を拡張: `activeTab/focusedArea` に `"issues"` を追加、
+    `issuesAvailability` / `issueItems` / `issueCursor` / `issueSyncing` /
+    `issueLastSync` / `issueLastError` を追加
+  - `buildIssueRows(state)` — 3 ブランチで disabled/available/empty を描画。
+    `[>|  ] PR #NUM  state  title  [labels]` 形式で cursor 強調
+  - Tab row に "Issues" ボタンを追加（`tab-issues`、`t("gh_tui_tab_title")`)
+  - キーバインド:
+    - `5` / `I` → `switchTab("issues")`
+    - `R` → `syncIssuesFromGh()`（rate limit 到達はエラー行表示）
+    - `Enter` / `O` → `openSelectedIssueInViewer()` — `formatIssueShow`
+      で一時 md に吐き、既存の `openArtifactInViewer` で開く（Must Fix 2）
+    - `B` → `html_url` を `open` で外部ブラウザ起動
+    - `↑` / `↓` → `issueCursor` 移動
+  - footer の hotkey hint に issues フォーカス時の行を追加
+  - グローバル footer に `5 issues` を追加
+  - ヘルパ関数: `loadIssuesFromCache` / `syncIssuesFromGh` /
+    `openSelectedIssueInViewer`。`switchTab("issues")` でキャッシュから
+    即時ロード
+
+テスト: `dashboard-issues.test.tsx` (8 件)。`buildIssueRows` をテスタブル
+にするため `export` を追加、`AppState` / `IssueListItem` も export。
+JSON シリアライズ比較でレンダリング結果を検証。
+
+### Phase 4 (commit 4b57a54) — Claude Code 誘導スキル `cmux-team-gh`
+
+- `skills/cmux-team-gh/SKILL.md` を新規作成
+  - trigger: issue/PR 番号言及 (`#272`, `issue 272`, `PR #42`, `T042`),
+    `gh issue list` / `gh pr view` / `ghe ...` の実行意図, レビュー待ち/open PR
+    などの問い合わせ
+  - 置換表: `gh issue list` → `cmux-team issue list` など 9 行
+  - `--sync` 付き読み取り、`gh status`, `gh sync --full` の月次運用推奨
+  - TUI Issues タブの操作（`5` / `I` / `R` / `Enter` / `O` / `B`）を案内
+  - 書き込み系 (`create` / `comment` / `merge` / `review`) は
+    **引き続き `gh` を使う**と明記
+  - 無効化される状況（非 git / 非 GitHub / 認証欠如）と exit code 早見表
+- `.claude-plugin/plugin.json` の `"skills": "./skills/"` が自動列挙する
+  ため変更不要
+
+## 不変条件の確認
+
+1. **main ブランチは無傷** — 全作業は `task-272-1776622205/task` ブランチ上
+2. **4 phase の分離 commit** — 各 Phase を独立 revert 可能
+3. **テスト先行 / カバレッジ** — CLI / format / store / sync / auth / repo /
+   TUI row builder に unit test あり
+4. **gh-compat JSON** — `author.login` / `assignees[].login` / `labels[].name`
+   / camelCase dates で既存 jq パイプラインが動く
+5. **i18n** — すべてのユーザー向け文字列を `t()` 経由で英日両対応
+6. **rate limit 安全** — ETag + since による 304 処理、`RateLimitExhaustedError`
+   で exit 4
+7. **トークン / repo 変更で自動 purge** — `openGhCacheDB` 内で不一致検出
+8. **non_git / no_auth の graceful degrade** — CLI は exit 2/3、TUI は
+   disabled メッセージ表示
+
+## テスト結果
+
+```
+$ bun test
+ 772 pass
+ 0 fail
+ 1883 expect() calls
+Ran 772 tests across 33 files. [36.83s]
+```
+
+pre-existing の tsc エラー 2 件（`conductor.ts:197`, `daemon.test.ts:3650`）は
+本タスクの対象外で、本変更では増減なし。
+
+## 主要ファイル一覧
+
+| ファイル | 行数 | 役割 |
+|---|---|---|
+| skills/cmux-team/manager/gh-cache-types.ts | 241 | zod スキーマ + 型 |
+| skills/cmux-team/manager/gh-cache-repo.ts | 97 | origin → host/owner/repo |
+| skills/cmux-team/manager/gh-cache-auth.ts | 102 | token 解決 |
+| skills/cmux-team/manager/gh-cache-store.ts | 687 | SQLite I/O |
+| skills/cmux-team/manager/gh-cache-sync.ts | 589 | REST 差分同期 |
+| skills/cmux-team/manager/gh-cache-format.ts | 241 | gh-compat JSON + text |
+| skills/cmux-team/manager/gh-cache-cli.ts | 328 | CLI subcommand |
+| skills/cmux-team/manager/dashboard.tsx | +291 | TUI Issues タブ追加 |
+| skills/cmux-team/manager/main.ts | +246 | cmdGh / cmdIssue / cmdPr |
+| skills/cmux-team/manager/i18n.ts | +122 | gh_* i18n (ja/en) |
+| skills/cmux-team-gh/SKILL.md | 143 | Claude 向け誘導スキル |
+| skills/cmux-team/manager/gh-cache-*.test.ts | 計 1,600 超 | unit test |
+
+## 既知の限界 / 今後の余地
+
+- **Projects V2** — plan §8 に記載。`project` scope 必須のため Phase 5
+  以降で対応
+- **本文の全文検索** — 現行は LIKE 検索のみ。将来的に FTS5 を追加する余地
+- **複数リポジトリ横断参照** — 各プロジェクトの `.team/gh-cache.db` は
+  独立。大規模 monorepo や複数 repo を同時に見たい場合は個別に同期が必要
+- **月次 `--full` の自動化** — 現状は手動。cron や `run_after_all` タスク
+  で自動化する余地あり
+
+## デプロイ手順
+
+1. `main` にマージ
+2. `npm version` でバージョン bump
+3. `npm publish` で `@hummer98/cmux-team` を公開
+4. ユーザー側で `npm install -g @hummer98/cmux-team` → 次回 Claude Code
+   起動時に `cmux-team-gh` skill が自動読み込まれる

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hummer98/cmux-team",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hummer98/cmux-team",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/skills/cmux-team-gh/SKILL.md
+++ b/skills/cmux-team-gh/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: cmux-team-gh
+description: >
+  Use when reading GitHub issues / PRs (github.com or GitHub Enterprise) from
+  the current project. Triggers: mention of an issue/PR number (e.g. "#272",
+  "issue 272", "PR #42"), user asks to run `gh issue`, `gh pr`, `ghe issue`,
+  `ghe pr`, wants to see review / comment status, or asks "show me open issues
+  / review requests / recent closed PRs". Use `cmux-team issue` /
+  `cmux-team pr` / `cmux-team gh` instead of invoking `gh` directly for READ
+  operations — the local SQLite cache avoids rate limit exhaustion. Writing
+  (create / comment / close / merge / review) still goes through `gh`.
+---
+
+# cmux-team-gh: GitHub issue/PR キャッシュ経由の読み取り
+
+このスキルは `cmux-team` plugin に同梱される GitHub issue/PR キャッシュの
+使い方リファレンスです。`gh issue` / `gh pr` の **読み取り系** は
+`cmux-team issue` / `cmux-team pr` に置き換えてください。
+
+## なぜ `gh` を直接使わないか
+
+- `gh` を叩くたびに GitHub API を呼ぶため、複数 issue を走査する用途
+  （レビュー待ち一覧、最近 close された PR の確認等）で rate limit を
+  消費しやすい。
+- `cmux-team gh sync` は ETag (`If-None-Match`) + `since=` による差分同期で、
+  変更がなければ **304 Not Modified**（rate limit 消費 0）で返る。
+- 同一プロジェクト内で複数エージェントが同じ issue を参照する場合、
+  キャッシュから読むため何度でも同じコストで読める。
+
+## トリガー判定（Claude 向け）
+
+以下のいずれかの場合にこのスキルを適用してください:
+
+- ユーザーが issue/PR 番号に言及（`#272`, `issue 272`, `PR #42`, `T042` 等）
+- ユーザーが `gh issue list` / `gh pr view` 等を実行したがっている
+- ユーザーが `ghe ...`（企業 GitHub）を実行したがっている — 同じキャッシュで読める
+- 「レビュー待ち」「open な PR」「直近 closed」「自分にアサインされた issue」等、
+  issue/PR の問い合わせ全般
+- `@me` に割り当てられた issue を探している
+- 特定ラベル（`bug`, `help wanted` 等）の絞り込みをしたい
+
+## 置換表
+
+| 代わりに | 使うもの |
+|---|---|
+| `gh issue list --state open --limit 20` | `cmux-team issue list --state open --limit 20` |
+| `gh issue list --assignee @me` | `cmux-team issue list --assignee @me` |
+| `gh issue list --label bug` | `cmux-team issue list --label bug` |
+| `gh issue view 272` | `cmux-team issue show 272` |
+| `gh issue view 272 --json title,body,labels` | `cmux-team issue show 272 --json title,body,labels` |
+| `gh pr list --state open` | `cmux-team pr list --state open` |
+| `gh pr view 42` | `cmux-team pr show 42` |
+| `gh pr view 42 --json state,title,reviews` | `cmux-team pr show 42 --json state,title,reviews` |
+| `gh search issues keyword` | `cmux-team issue search keyword` |
+
+JSON 出力のキー名は `gh --json` 互換です（`author.login`,
+`assignees[].login`, `labels[].name`, `createdAt`, `mergedAt` など）。
+既存の jq パイプラインをそのまま使えます。
+
+```bash
+# 例: open PR の author 一覧を取得
+cmux-team pr list --state open --json number,title,author.login
+```
+
+## キャッシュが古いと感じたら
+
+- **差分同期（ほぼ無料）**: `cmux-team gh sync`
+  - 前回同期以降に更新された issue/PR のみ取得
+  - 変更がなければ 304 Not Modified
+- **フル同期**: `cmux-team gh sync --full`
+  - 直近 500 件の issue/PR を最初から取得
+  - 初回実行 / トークン変更 / **月 1 回の運用推奨**
+  - 削除・transfer された issue を cleanup する唯一の手段
+- **状態確認**: `cmux-team gh status`
+  - 最終 sync 時刻、rate limit 残量、viewer login、issue/PR 件数
+  - 「最終 full sync から N 日経過」表示に注意
+  - 30 日を超えたら `--full` 推奨
+
+### 省略コマンドとしての `--sync`
+
+一発で同期 + 読み取りを行いたい場合は list/show に `--sync` を付けられます:
+
+```bash
+cmux-team issue list --state open --sync    # 事前 incremental sync してから表示
+cmux-team issue show 272 --sync              # 対象 issue を同期してから表示
+```
+
+## TUI Issues タブ
+
+`cmux-team start` で起動する Manager ダッシュボードには「Issues」タブが
+あります（キーバインド `5` または `I`）。
+
+- `R` — incremental sync を走らせる
+- `Enter` / `O` — 選択中 issue を markdown ビューアで開く
+- `B` — 選択中 issue の GitHub URL をブラウザで開く
+- `↑` / `↓` — カーソル移動
+
+## 書き込み系は `gh` を使う
+
+以下の操作は本 skill の対象外です。引き続き `gh` を使ってください:
+
+- `gh issue create` — issue 作成
+- `gh issue comment` / `gh pr comment` — コメント追加
+- `gh issue close` / `gh pr close` — クローズ
+- `gh pr merge` — マージ
+- `gh pr review` — レビュー送信
+
+書き込みを行った後は `cmux-team gh sync` でキャッシュを更新してください。
+
+## 無効化される状況
+
+以下の場合、このスキルは使えません。従来通り `gh` を直接使ってください:
+
+- 起動ディレクトリが git repo でない（exit 2）
+- `origin` が GitHub / GHE でない（exit 2）
+- 認証トークンが無い（exit 3）
+  - `gh auth login` を実行するか、`GITHUB_TOKEN` / `GH_TOKEN` を設定
+
+### rate limit 到達時（exit 4）
+
+`cmux-team gh sync` が exit 4 を返した場合、しばらく待って（`reset_at`
+表示を参照）再度実行してください。`cmux-team issue list --stale-ok` で
+警告を抑止して古いキャッシュから読み続けることも可能です。
+
+## Exit codes
+
+| code | 意味 |
+|---|---|
+| 0 | 成功 |
+| 1 | 汎用エラー |
+| 2 | 非 git / 非 GitHub origin |
+| 3 | 認証欠如 |
+| 4 | rate limit 到達 |
+
+## キャッシュの場所
+
+- DB: `.team/gh-cache.db`（SQLite WAL）
+- 本文 / raw JSON は同 DB 内に格納（別ファイルなし）
+- トークンハッシュ不一致 / 異なる repo を検出したら自動 purge
+
+プロジェクト毎に独立したキャッシュを持つため、複数リポジトリを横断して
+参照する用途には使えません（各リポジトリで個別に `cmux-team start` /
+`cmux-team gh sync` を走らせてください）。

--- a/skills/cmux-team/manager/dashboard-issues.test.tsx
+++ b/skills/cmux-team/manager/dashboard-issues.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * buildIssueRows (Issues タブの行ビルダー) のユニットテスト。
+ *
+ * Rezi UI の `ui.text` / `ui.row` オブジェクトはそのまま比較しにくいため、
+ * ここでは「行数」と「行オブジェクトが期待するテキストを含むかどうか」を
+ * JSON シリアライズしてから assert する。
+ */
+import { describe, test, expect } from "bun:test";
+import { buildIssueRows, type AppState, type IssueListItem } from "./dashboard";
+import type { IssueRow, LabelRow, AssigneeRow } from "./gh-cache-types";
+
+function makeIssue(overrides: Partial<IssueRow> = {}): IssueRow {
+  return {
+    number: 1,
+    type: "issue",
+    state: "open",
+    title: "hello",
+    body: null,
+    author_login: "alice",
+    author_id: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    html_url: "https://github.com/acme/widget/issues/1",
+    comments_count: 0,
+    milestone_id: null,
+    draft: null,
+    etag: null,
+    fetched_at: "2026-01-03T00:00:00Z",
+    raw_json: null,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    daemon: {} as any,
+    activeTab: "issues",
+    journalEntries: [],
+    logLines: [],
+    artifacts: [],
+    artifactCursor: 0,
+    artifactSort: "id",
+    artifactTypeFilter: null,
+    artifactSearch: null,
+    taskCursor: 0,
+    version: "",
+    repoUrl: null,
+    logScrollOffset: 0,
+    logAutoScroll: true,
+    spinnerFrame: 0,
+    focusedArea: "issues",
+    journalScrollOffset: 0,
+    journalAutoScroll: true,
+    settingsItems: [],
+    settingsCursor: 0,
+    issuesAvailability: "available",
+    issueItems: [],
+    issueCursor: 0,
+    issueSyncing: false,
+    issueLastSync: null,
+    issueLastError: null,
+    ...overrides,
+  };
+}
+
+function stringifyRows(rows: any[]): string {
+  return JSON.stringify(rows);
+}
+
+describe("buildIssueRows", () => {
+  test("non_git の場合 disabled メッセージを返す", () => {
+    const rows = buildIssueRows(makeState({ issuesAvailability: "non_git" }));
+    expect(rows.length).toBe(1);
+    const s = stringifyRows(rows);
+    // 英日どちらのロケールでも "git" を含む
+    expect(s).toContain("git");
+  });
+
+  test("no_auth の場合 disabled メッセージを返す", () => {
+    const rows = buildIssueRows(makeState({ issuesAvailability: "no_auth" }));
+    expect(rows.length).toBe(1);
+    const s = stringifyRows(rows);
+    // 英日どちらのロケールでも "auth" or "認証" を含む
+    expect(s.toLowerCase().includes("auth") || s.includes("認証")).toBe(true);
+  });
+
+  test("available + 空の場合 empty メッセージを返す", () => {
+    const rows = buildIssueRows(makeState({ issuesAvailability: "available", issueItems: [] }));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    // empty メッセージは gh_issue_empty（英: "no issues" / 日: "該当する issue"）
+    const s = stringifyRows(rows);
+    expect(s.toLowerCase().includes("issue") || s.includes("該当")).toBe(true);
+  });
+
+  test("last sync 行が表示される", () => {
+    const rows = buildIssueRows(
+      makeState({
+        issueLastSync: "2026-04-20T12:00:00Z",
+        issueItems: [],
+      }),
+    );
+    const s = stringifyRows(rows);
+    expect(s).toContain("last sync");
+    expect(s).toContain("2026-04-20T12:00:00Z");
+  });
+
+  test("syncing 中はプログレス表記", () => {
+    const rows = buildIssueRows(
+      makeState({
+        issueLastSync: null,
+        issueSyncing: true,
+        issueItems: [],
+      }),
+    );
+    const s = stringifyRows(rows);
+    // 英日: "Syncing" または "同期"
+    expect(s.toLowerCase().includes("syncing") || s.includes("同期")).toBe(true);
+  });
+
+  test("issueItems を行としてレンダリング", () => {
+    const items: IssueListItem[] = [
+      {
+        issue: makeIssue({ number: 42, title: "bug fix", type: "issue" }),
+        labels: [{ id: 1, name: "bug", color: "f00", description: null }],
+        assignees: [{ id: 1, login: "bob", avatar_url: null }],
+      },
+      {
+        issue: makeIssue({ number: 7, title: "new feature", type: "pr" }),
+        labels: [],
+        assignees: [],
+      },
+    ];
+    const rows = buildIssueRows(makeState({ issueItems: items }));
+    // 2 個の行が出るはず (last_sync なし、error なし)
+    expect(rows.length).toBe(2);
+    const s = stringifyRows(rows);
+    expect(s).toContain("#42");
+    expect(s).toContain("bug fix");
+    expect(s).toContain("[bug]"); // labels
+    expect(s).toContain("#7");
+    expect(s).toContain("new feature");
+    expect(s).toContain("PR"); // type prefix
+  });
+
+  test("cursor 位置の行が強調される", () => {
+    const items: IssueListItem[] = [
+      {
+        issue: makeIssue({ number: 1, title: "a" }),
+        labels: [],
+        assignees: [],
+      },
+      {
+        issue: makeIssue({ number: 2, title: "b" }),
+        labels: [],
+        assignees: [],
+      },
+    ];
+    const rows = buildIssueRows(makeState({ issueItems: items, issueCursor: 1 }));
+    // JSON 内で 2 番目の行に ">" 記号（選択マーカー）が入っているはず
+    const s = stringifyRows(rows);
+    expect(s).toContain(">");
+  });
+
+  test("エラーがあれば最終行に表示", () => {
+    const rows = buildIssueRows(
+      makeState({
+        issueItems: [],
+        issueLastError: "rate limit: remaining=0 reset=...",
+      }),
+    );
+    const s = stringifyRows(rows);
+    expect(s).toContain("rate limit");
+  });
+});

--- a/skills/cmux-team/manager/dashboard.tsx
+++ b/skills/cmux-team/manager/dashboard.tsx
@@ -26,6 +26,20 @@ import { listProjectInstructions, readProjectInstructions } from "./agent-instru
 import { loadConfig, type TeamConfig } from "./config";
 import type { AgentRole } from "./schema";
 import { AGENT_ROLES } from "./schema";
+import { resolveOriginRepo } from "./gh-cache-repo";
+import { resolveGithubToken, tokenHash } from "./gh-cache-auth";
+import {
+  openGhCacheDB,
+  listIssues,
+  getIssueLabels,
+  getIssueAssignees,
+  getSyncMeta,
+} from "./gh-cache-store";
+import { displayState } from "./gh-cache-format";
+import type { IssueRow, LabelRow, AssigneeRow } from "./gh-cache-types";
+import { syncIncremental, RateLimitExhaustedError } from "./gh-cache-sync";
+import { writeFile } from "fs/promises";
+import { tmpdir } from "os";
 
 const LOG_VISIBLE_LINES = 30;
 const TASK_VISIBLE_LINES = 5;
@@ -368,9 +382,15 @@ type SettingsItem =
       value: string;
     };
 
-interface AppState {
+export interface IssueListItem {
+  issue: IssueRow;
+  labels: LabelRow[];
+  assignees: AssigneeRow[];
+}
+
+export interface AppState {
   daemon: DaemonState;
-  activeTab: "journal" | "artifacts" | "log" | "settings";
+  activeTab: "journal" | "artifacts" | "log" | "settings" | "issues";
   journalEntries: JournalEntry[];
   logLines: string[];
   artifacts: ArtifactMeta[];
@@ -385,11 +405,18 @@ interface AppState {
   logScrollOffset: number;   // 0 = 先頭（最新）、正の数 = 下にスクロールした行数（古い方へ）
   logAutoScroll: boolean;    // true = 最新に自動追従
   spinnerFrame: number;      // スピナーアニメーション用フレームカウンター
-  focusedArea: "global" | "tasks" | "journal" | "log" | "artifacts" | "settings";
+  focusedArea: "global" | "tasks" | "journal" | "log" | "artifacts" | "settings" | "issues";
   journalScrollOffset: number;  // 0 = 先頭（最新）、正の数 = 下にスクロールした行数（古い方へ）
   journalAutoScroll: boolean;   // true = 最新に自動追従
   settingsItems: SettingsItem[];
   settingsCursor: number;
+  // ── gh-cache Issues タブ (T272 Phase 3) ─────────────────────────
+  issuesAvailability: "available" | "non_git" | "no_auth" | "unknown";
+  issueItems: IssueListItem[];
+  issueCursor: number;
+  issueSyncing: boolean;
+  issueLastSync: string | null;  // 表示用（ISO 文字列 or null）
+  issueLastError: string | null;
 }
 
 // --- スピナー定義 ---
@@ -865,6 +892,63 @@ function buildArtifactRows(state: AppState): any[] {
   return rows;
 }
 
+/**
+ * gh-cache Issues タブの行を描画する (T272 Phase 3)
+ *
+ * - 非 git / 認証なしなら disabled メッセージ
+ * - sync 中はプログレス行
+ * - エラーがあれば最下行に表示
+ */
+export function buildIssueRows(state: AppState): any[] {
+  if (state.issuesAvailability === "non_git") {
+    return [ui.text(t("gh_tui_disabled_non_git"), { dim: true })];
+  }
+  if (state.issuesAvailability === "no_auth") {
+    return [ui.text(t("gh_tui_disabled_no_auth"), { dim: true })];
+  }
+
+  const rows: any[] = [];
+  if (state.issueLastSync) {
+    rows.push(
+      ui.text(
+        `last sync: ${state.issueLastSync}${state.issueSyncing ? " • " + t("gh_tui_syncing") : ""}`,
+        { dim: true },
+      ),
+    );
+  } else if (state.issueSyncing) {
+    rows.push(ui.text(t("gh_tui_syncing"), { dim: true }));
+  }
+
+  if (state.issueItems.length === 0) {
+    rows.push(ui.text(t("gh_issue_empty"), { dim: true }));
+  } else {
+    for (let i = 0; i < state.issueItems.length; i++) {
+      const item = state.issueItems[i]!;
+      const isSelected = i === state.issueCursor;
+      const stateStr = displayState(item.issue).padEnd(7);
+      const typePrefix = item.issue.type === "pr" ? "PR" : "  ";
+      const parts = [
+        ui.text(isSelected ? ">" : " ", isSelected ? { bold: true } : {}),
+        ui.text(typePrefix, { dim: true }),
+        ui.text(`#${item.issue.number}`, { style: { bold: isSelected, fg: GRAY } }),
+        ui.text(stateStr, { dim: true }),
+        ui.text(item.issue.title, isSelected ? { bold: true } : {}),
+        item.labels.length > 0
+          ? ui.text(`[${item.labels.map((l) => l.name).join(", ")}]`, { dim: true })
+          : null,
+      ];
+      rows.push(ui.row({ gap: 1 }, parts));
+    }
+  }
+
+  if (state.issueLastError) {
+    rows.push(ui.text(""));
+    rows.push(ui.text(state.issueLastError, { dim: true }));
+  }
+
+  return rows;
+}
+
 function buildLogRows(lines: string[]) {
   if (lines.length === 0) {
     return [ui.text("no log entries", { dim: true })];
@@ -1073,6 +1157,12 @@ export async function startDashboard(
       journalAutoScroll: true,
       settingsItems: [],
       settingsCursor: 0,
+      issuesAvailability: "unknown",
+      issueItems: [],
+      issueCursor: 0,
+      issueSyncing: false,
+      issueLastSync: null,
+      issueLastError: null,
     },
     config: { executionMode: "inline" },
   });
@@ -1224,6 +1314,13 @@ export async function startDashboard(
             style: state.activeTab === "settings" ? { bold: true } : { dim: true },
             onPress: () => switchTab("settings"),
           }),
+          ui.button({
+            id: "tab-issues",
+            label: t("gh_tui_tab_title"),
+            px: 1,
+            style: state.activeTab === "issues" ? { bold: true } : { dim: true },
+            onPress: () => switchTab("issues"),
+          }),
         ]),
         ui.column({ gap: 0 },
           state.activeTab === "journal"
@@ -1239,6 +1336,8 @@ export async function startDashboard(
             ? buildArtifactRows(state)
             : state.activeTab === "settings"
             ? buildSettingsRows(state)
+            : state.activeTab === "issues"
+            ? buildIssueRows(state)
             : (() => {
                 // 逆順表示: 最新が先頭、offset=0 で最新を表示
                 const reversed = [...state.logLines].reverse();
@@ -1302,12 +1401,22 @@ export async function startDashboard(
               ui.kbd("L"), ui.text("log"),
               ui.kbd("ESC"), ui.text("back"),
             ]
+          : state.focusedArea === "issues"
+          ? [
+              ui.kbd("↑/↓"), ui.text("select"),
+              ui.kbd("Enter/O"), ui.text("view"),
+              ui.kbd("R"), ui.text("sync"),
+              ui.kbd("B"), ui.text("browser"),
+              ui.kbd("J"), ui.text("journal"),
+              ui.kbd("ESC"), ui.text("back"),
+            ]
           : [ // global
               ui.kbd("T"), ui.text("tasks"),
               ui.kbd("J"), ui.text("journal"),
               ui.kbd("L"), ui.text("log"),
               ui.kbd("A"), ui.text("artifacts"),
               ui.kbd("4"), ui.text("settings"),
+              ui.kbd("5"), ui.text("issues"),
               ui.kbd("r"), ui.text("reload"),
               ui.kbd("q"), ui.text("quit"),
               ui.kbd("Q"), ui.text("full quit"),
@@ -1325,6 +1434,7 @@ export async function startDashboard(
     artifacts: "artifacts",
     log: "log",
     settings: "settings",
+    issues: "issues",
   };
   // D17: refresh() が settings 再読み込みすべきかどうか判定するためのミラー
   let currentActiveTab: TabId = "journal";
@@ -1335,6 +1445,10 @@ export async function startDashboard(
       // settings に切り替えた直後は即時ロード
       if (tab === "settings") {
         refresh().catch(() => {});
+      }
+      // issues に切り替えたら cache から即時ロード
+      if (tab === "issues") {
+        loadIssuesFromCache().catch(() => {});
       }
     } catch {}
   }
@@ -1364,6 +1478,9 @@ export async function startDashboard(
           while (c >= 0 && s.settingsItems[c]?.kind === "section") c--;
           return { ...s, settingsCursor: Math.max(c, 0) };
         }
+        case "issues": {
+          return { ...s, issueCursor: Math.max(s.issueCursor - 1, 0) };
+        }
         default:
           return s;
       }
@@ -1392,6 +1509,10 @@ export async function startDashboard(
           while (c <= max && s.settingsItems[c]?.kind === "section") c++;
           return { ...s, settingsCursor: Math.min(c, max) };
         }
+        case "issues": {
+          const max = Math.max(s.issueItems.length - 1, 0);
+          return { ...s, issueCursor: Math.min(s.issueCursor + 1, max) };
+        }
         default:
           return s;
       }
@@ -1400,8 +1521,9 @@ export async function startDashboard(
     "2": () => switchTab("artifacts"),
     "3": () => switchTab("log"),
     "4": () => switchTab("settings"),
+    "5": () => switchTab("issues"),
     Tab: (ctx) => {
-      const tabs: AppState["activeTab"][] = ["journal", "artifacts", "log", "settings"];
+      const tabs: AppState["activeTab"][] = ["journal", "artifacts", "log", "settings", "issues"];
       const idx = tabs.indexOf(ctx.state.activeTab);
       const next = tabs[(idx + 1) % tabs.length]!;
       switchTab(next);
@@ -1410,6 +1532,29 @@ export async function startDashboard(
     J: () => switchTab("journal"),
     L: () => switchTab("log"),
     A: () => switchTab("artifacts"),
+    I: () => switchTab("issues"),
+    R: (ctx) => {
+      if (ctx.state.focusedArea !== "issues") return;
+      syncIssuesFromGh().catch((e: any) => {
+        log("issues_sync_error", e?.message ?? String(e)).catch(() => {});
+      });
+    },
+    B: (ctx) => {
+      if (ctx.state.focusedArea !== "issues") return;
+      const item = ctx.state.issueItems[ctx.state.issueCursor];
+      if (!item?.issue.html_url) return;
+      try {
+        Bun.spawn(["open", item.issue.html_url], { stdio: ["ignore", "ignore", "ignore"] });
+      } catch (e: any) {
+        log("issues_open_browser_failed", e?.message ?? String(e)).catch(() => {});
+      }
+    },
+    O: (ctx) => {
+      if (ctx.state.focusedArea !== "issues") return;
+      openSelectedIssueInViewer(ctx.state).catch((e: any) => {
+        log("viewer_error", e?.message ?? String(e)).catch(() => {});
+      });
+    },
     // Artifacts タブ専用キー
     Enter: (ctx) => {
       const currentState = ctx.state;
@@ -1448,6 +1593,13 @@ export async function startDashboard(
             refresh();
           },
         ).catch((e: any) => { log("viewer_error", e?.message ?? String(e)).catch(() => {}); });
+        return;
+      }
+      // issues タブ: 選択中 issue を formatIssueShow でビューアに表示
+      if (currentState.focusedArea === "issues") {
+        openSelectedIssueInViewer(currentState).catch((e: any) => {
+          log("viewer_error", e?.message ?? String(e)).catch(() => {});
+        });
         return;
       }
 
@@ -1531,6 +1683,137 @@ export async function startDashboard(
   });
 
   appInstance = app;
+
+  // --- gh-cache Issues タブ用ヘルパ (T272 Phase 3) ---
+
+  /**
+   * キャッシュ DB から issue/PR 一覧を読み出して state に反映する。
+   * 非 git / 認証なしの場合は availability を更新して早期 return する。
+   */
+  async function loadIssuesFromCache(): Promise<void> {
+    const projectRoot = getState().projectRoot;
+    try {
+      const repoInfo = await resolveOriginRepo(projectRoot);
+      if (!repoInfo) {
+        app.update((s) => ({ ...s, issuesAvailability: "non_git" }));
+        return;
+      }
+      const auth = await resolveGithubToken(repoInfo.host);
+      if (!auth.token) {
+        app.update((s) => ({ ...s, issuesAvailability: "no_auth" }));
+        return;
+      }
+      const db = openGhCacheDB(projectRoot, repoInfo, tokenHash(auth.token));
+      try {
+        const rows = listIssues(db, { state: "open", limit: 100 });
+        const items: IssueListItem[] = rows.map((r) => ({
+          issue: r,
+          labels: getIssueLabels(db, r.number),
+          assignees: getIssueAssignees(db, r.number),
+        }));
+        const meta = getSyncMeta(db);
+        app.update((s) => ({
+          ...s,
+          issuesAvailability: "available",
+          issueItems: items,
+          issueCursor: Math.min(s.issueCursor, Math.max(items.length - 1, 0)),
+          issueLastSync: meta?.last_incremental_sync ?? meta?.last_full_sync ?? null,
+          issueLastError: null,
+        }));
+      } finally {
+        db.close();
+      }
+    } catch (e: any) {
+      log("issues_load_error", e?.message ?? String(e)).catch(() => {});
+      app.update((s) => ({
+        ...s,
+        issueLastError: e?.message ?? String(e),
+      }));
+    }
+  }
+
+  /**
+   * incremental sync を走らせてから再ロードする。
+   * R キーから呼ばれる。rate limit 到達時はエラー表示のみ。
+   */
+  async function syncIssuesFromGh(): Promise<void> {
+    const projectRoot = getState().projectRoot;
+    const repoInfo = await resolveOriginRepo(projectRoot);
+    if (!repoInfo) {
+      app.update((s) => ({ ...s, issuesAvailability: "non_git" }));
+      return;
+    }
+    const auth = await resolveGithubToken(repoInfo.host);
+    if (!auth.token) {
+      app.update((s) => ({ ...s, issuesAvailability: "no_auth" }));
+      return;
+    }
+    app.update((s) => ({ ...s, issueSyncing: true, issueLastError: null }));
+    const db = openGhCacheDB(projectRoot, repoInfo, tokenHash(auth.token));
+    try {
+      await syncIncremental({
+        db,
+        repoInfo,
+        auth: { ...auth, token: auth.token },
+      });
+      app.update((s) => ({ ...s, issueSyncing: false }));
+    } catch (e: any) {
+      const msg =
+        e instanceof RateLimitExhaustedError
+          ? `rate limit: remaining=${e.rateLimit.remaining ?? "?"} reset=${e.rateLimit.resetAt ?? "?"}`
+          : e?.message ?? String(e);
+      app.update((s) => ({ ...s, issueSyncing: false, issueLastError: msg }));
+    } finally {
+      db.close();
+    }
+    await loadIssuesFromCache();
+  }
+
+  /**
+   * 選択中 issue を formatIssueShow でファイルに吐き、openArtifactInViewer で開く。
+   */
+  async function openSelectedIssueInViewer(state: AppState): Promise<void> {
+    const item = state.issueItems[state.issueCursor];
+    if (!item) return;
+    const { formatIssueShow } = await import("./gh-cache-format");
+    const { getIssueComments, getPrReviews, getPrReviewComments } = await import(
+      "./gh-cache-store"
+    );
+    const projectRoot = getState().projectRoot;
+    const repoInfo = await resolveOriginRepo(projectRoot);
+    if (!repoInfo) return;
+    const auth = await resolveGithubToken(repoInfo.host);
+    if (!auth.token) return;
+    const db = openGhCacheDB(projectRoot, repoInfo, tokenHash(auth.token));
+    let content: string;
+    try {
+      const comments = getIssueComments(db, item.issue.number);
+      const rel: any = {
+        issue: item.issue,
+        labels: item.labels,
+        assignees: item.assignees,
+        comments,
+      };
+      if (item.issue.type === "pr") {
+        rel.reviews = getPrReviews(db, item.issue.number);
+        rel.reviewComments = getPrReviewComments(db, item.issue.number);
+      }
+      content = formatIssueShow(rel);
+    } finally {
+      db.close();
+    }
+    const tmpPath = join(tmpdir(), `cmux-team-issue-${item.issue.number}.md`);
+    await writeFile(tmpPath, content, "utf-8");
+    await openArtifactInViewer(app, tmpPath, () => {
+      dashboardActive = true;
+      spinnerInterval = setInterval(() => {
+        try {
+          app.update((s) => ({ ...s, spinnerFrame: s.spinnerFrame + 1 }));
+        } catch {}
+      }, SPINNER_INTERVAL);
+      refresh();
+    });
+  }
 
   // 2000ms ごとに状態更新
   const refresh = async () => {

--- a/skills/cmux-team/manager/gh-cache-auth.test.ts
+++ b/skills/cmux-team/manager/gh-cache-auth.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  tokenHash,
+  ghCliHostname,
+  resolveGithubToken,
+} from "./gh-cache-auth";
+
+const ENV_KEYS = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GH_ENTERPRISE_TOKEN",
+  "GITHUB_ENTERPRISE_TOKEN",
+];
+
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = {};
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] !== undefined) process.env[k] = saved[k];
+    else delete process.env[k];
+  }
+});
+
+describe("tokenHash", () => {
+  test("長さ 32 の 16 進文字列", () => {
+    const h = tokenHash("ghp_abcdef1234567890");
+    expect(h).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("同じ入力 → 同じ出力", () => {
+    expect(tokenHash("x")).toBe(tokenHash("x"));
+  });
+
+  test("違う入力 → 違う出力", () => {
+    expect(tokenHash("a")).not.toBe(tokenHash("b"));
+  });
+});
+
+describe("ghCliHostname", () => {
+  test("api.github.com → github.com", () => {
+    expect(ghCliHostname("api.github.com")).toBe("github.com");
+  });
+
+  test("GHE `/api/v3` は落とす", () => {
+    expect(ghCliHostname("ghe.example.com/api/v3")).toBe("ghe.example.com");
+  });
+
+  test("`/api/v3` なしの GHE もそのまま", () => {
+    expect(ghCliHostname("ghe.example.com")).toBe("ghe.example.com");
+  });
+});
+
+describe("resolveGithubToken", () => {
+  test("GITHUB_TOKEN が優先される (github.com)", async () => {
+    process.env.GITHUB_TOKEN = "token_A";
+    process.env.GH_TOKEN = "token_B";
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async () => "token_cli",
+    });
+    expect(r.kind).toBe("env");
+    if (r.kind === "env") expect(r.token).toBe("token_A");
+  });
+
+  test("GITHUB_TOKEN が無ければ GH_TOKEN", async () => {
+    process.env.GH_TOKEN = "token_B";
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async () => "token_cli",
+    });
+    expect(r.kind).toBe("env");
+    if (r.kind === "env") expect(r.token).toBe("token_B");
+  });
+
+  test("env 無ければ gh CLI", async () => {
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async (h) => {
+        expect(h).toBe("github.com");
+        return "cli_token";
+      },
+    });
+    expect(r.kind).toBe("gh-cli");
+    if (r.kind === "gh-cli") expect(r.token).toBe("cli_token");
+  });
+
+  test("どこにもなければ kind=none", async () => {
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async () => undefined,
+    });
+    expect(r.kind).toBe("none");
+  });
+
+  test("GHE は GH_ENTERPRISE_TOKEN を優先", async () => {
+    process.env.GITHUB_TOKEN = "wrong";
+    process.env.GH_ENTERPRISE_TOKEN = "ghe_A";
+    process.env.GITHUB_ENTERPRISE_TOKEN = "ghe_B";
+    const r = await resolveGithubToken("ghe.example.com/api/v3", {
+      ghCliTokenFn: async () => "cli",
+    });
+    expect(r.kind).toBe("env");
+    if (r.kind === "env") expect(r.token).toBe("ghe_A");
+  });
+
+  test("GHE で GH_ENTERPRISE_TOKEN が無ければ GITHUB_ENTERPRISE_TOKEN", async () => {
+    process.env.GITHUB_ENTERPRISE_TOKEN = "ghe_B";
+    const r = await resolveGithubToken("ghe.example.com/api/v3", {
+      ghCliTokenFn: async () => "cli",
+    });
+    expect(r.kind).toBe("env");
+    if (r.kind === "env") expect(r.token).toBe("ghe_B");
+  });
+
+  test("checked 配列に確認した env 名と gh コマンドが入る", async () => {
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async () => undefined,
+    });
+    expect(r.checked).toContain("GITHUB_TOKEN");
+    expect(r.checked).toContain("GH_TOKEN");
+    expect(r.checked.some((s) => s.startsWith("gh auth token"))).toBe(true);
+  });
+
+  test("空白だけの env は無視される", async () => {
+    process.env.GITHUB_TOKEN = "   ";
+    const r = await resolveGithubToken("api.github.com", {
+      ghCliTokenFn: async () => "cli",
+    });
+    expect(r.kind).toBe("gh-cli");
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-auth.ts
+++ b/skills/cmux-team/manager/gh-cache-auth.ts
@@ -1,0 +1,102 @@
+/**
+ * gh-cache: GitHub トークン解決。
+ *
+ * 優先順位（plan §4）:
+ *   1. host=api.github.com: GITHUB_TOKEN → GH_TOKEN → `gh auth token --hostname github.com`
+ *   2. host=GHE: GH_ENTERPRISE_TOKEN → GITHUB_ENTERPRISE_TOKEN → `gh auth token --hostname <host>`
+ *
+ * 失敗時は kind="none" を返す（crash しない）。
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { createHash } from "crypto";
+import type { AuthResolution } from "./gh-cache-types";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * トークンハッシュ（32 hex = sha256 先頭 32 文字）。
+ * 監査ログで識別しやすい長さかつ衝突確率は実用十分。
+ */
+export function tokenHash(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 32);
+}
+
+/**
+ * env 優先順のトークン候補リスト（host 依存）。
+ */
+function envCandidates(host: string): Array<{ name: string; value: string | undefined }> {
+  const isGheHost = !host.startsWith("api.github.com");
+  if (isGheHost) {
+    return [
+      { name: "GH_ENTERPRISE_TOKEN", value: process.env.GH_ENTERPRISE_TOKEN },
+      { name: "GITHUB_ENTERPRISE_TOKEN", value: process.env.GITHUB_ENTERPRISE_TOKEN },
+    ];
+  }
+  return [
+    { name: "GITHUB_TOKEN", value: process.env.GITHUB_TOKEN },
+    { name: "GH_TOKEN", value: process.env.GH_TOKEN },
+  ];
+}
+
+/**
+ * host から `gh auth token --hostname <X>` の X 部分を決める。
+ * "api.github.com" → "github.com"
+ * "ghe.example.com/api/v3" → "ghe.example.com"
+ */
+export function ghCliHostname(host: string): string {
+  if (host === "api.github.com") return "github.com";
+  const slash = host.indexOf("/");
+  return slash > 0 ? host.slice(0, slash) : host;
+}
+
+/**
+ * gh CLI からトークン取得。存在しない / 失敗時は undefined。
+ * テスト差し替えのため関数参照を export する。
+ */
+export async function ghCliToken(hostname: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("gh", [
+      "auth",
+      "token",
+      "--hostname",
+      hostname,
+    ]);
+    const token = stdout.trim();
+    return token.length > 0 ? token : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * トークン解決。env → gh CLI の順で試し、見つかったら即返す。
+ * plan §4 の優先順位に従う。
+ */
+export async function resolveGithubToken(
+  host: string,
+  opts: {
+    /** テスト用: gh CLI 呼び出しを差し替える */
+    ghCliTokenFn?: (hostname: string) => Promise<string | undefined>;
+  } = {},
+): Promise<AuthResolution> {
+  const checked: string[] = [];
+  const candidates = envCandidates(host);
+
+  for (const { name, value } of candidates) {
+    checked.push(name);
+    if (value && value.trim().length > 0) {
+      return { kind: "env", token: value.trim(), host, checked };
+    }
+  }
+
+  const cliHost = ghCliHostname(host);
+  checked.push(`gh auth token --hostname ${cliHost}`);
+  const fn = opts.ghCliTokenFn ?? ghCliToken;
+  const token = await fn(cliHost);
+  if (token) {
+    return { kind: "gh-cli", token, host, checked };
+  }
+
+  return { kind: "none", host, checked };
+}

--- a/skills/cmux-team/manager/gh-cache-cli.test.ts
+++ b/skills/cmux-team/manager/gh-cache-cli.test.ts
@@ -1,0 +1,342 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openGhCacheDB,
+  upsertIssue,
+  upsertLabel,
+  upsertAssignee,
+  linkIssueLabel,
+  linkIssueAssignee,
+  setSyncMeta,
+} from "./gh-cache-store";
+import {
+  cmdIssueList,
+  cmdIssueShow,
+  cmdIssueSearch,
+  cmdPrList,
+  type CliDeps,
+} from "./gh-cache-cli";
+import type { IssueRow, RepoInfo, AuthResolution } from "./gh-cache-types";
+
+const REPO: RepoInfo = { host: "api.github.com", owner: "acme", repo: "widget" };
+const TOKEN_HASH = "a".repeat(32);
+
+let testDir: string;
+let db: ReturnType<typeof openGhCacheDB>;
+let printed: string[];
+
+function makeIssue(overrides: Partial<IssueRow> = {}): IssueRow {
+  return {
+    number: 1,
+    type: "issue",
+    state: "open",
+    title: "sample",
+    body: "hello",
+    author_login: "alice",
+    author_id: 100,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    html_url: "https://github.com/acme/widget/issues/1",
+    comments_count: 0,
+    milestone_id: null,
+    draft: null,
+    etag: null,
+    fetched_at: "2026-01-03T00:00:00Z",
+    raw_json: null,
+    ...overrides,
+  };
+}
+
+function makeDeps(args: string[]): CliDeps {
+  const auth: AuthResolution & { token: string } = {
+    kind: "env",
+    token: "xxx",
+    host: REPO.host,
+    checked: ["GITHUB_TOKEN"],
+  };
+  return {
+    db,
+    repoInfo: REPO,
+    auth,
+    args,
+    stdout: (s) => printed.push(s),
+  };
+}
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "gh-cli-test-"));
+  db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+  printed = [];
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe("cmdIssueList", () => {
+  test("state=open のみ返る（デフォルト）", async () => {
+    upsertIssue(db, makeIssue({ number: 1, state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, state: "closed" }));
+    await cmdIssueList(makeDeps(["issue", "list"]));
+    expect(printed.some((l) => l.includes("#1"))).toBe(true);
+    expect(printed.some((l) => l.includes("#2"))).toBe(false);
+  });
+
+  test("PR はリスト除外", async () => {
+    upsertIssue(db, makeIssue({ number: 1, type: "issue", state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, type: "pr", state: "open" }));
+    await cmdIssueList(makeDeps(["issue", "list"]));
+    expect(printed.some((l) => l.includes("#1"))).toBe(true);
+    expect(printed.some((l) => l.includes("#2"))).toBe(false);
+  });
+
+  test("--state closed", async () => {
+    upsertIssue(db, makeIssue({ number: 1, state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, state: "closed" }));
+    await cmdIssueList(makeDeps(["issue", "list", "--state", "closed"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+
+  test("--state all", async () => {
+    upsertIssue(db, makeIssue({ number: 1, state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, state: "closed" }));
+    await cmdIssueList(makeDeps(["issue", "list", "--state", "all"]));
+    const text = printed.join("\n");
+    expect(text).toContain("#1");
+    expect(text).toContain("#2");
+  });
+
+  test("--limit N", async () => {
+    for (let i = 1; i <= 5; i++) {
+      upsertIssue(db, makeIssue({ number: i, updated_at: `2026-01-0${i}T00:00:00Z` }));
+    }
+    await cmdIssueList(makeDeps(["issue", "list", "--state", "all", "--limit", "2"]));
+    expect(printed.length).toBe(2);
+  });
+
+  test("--assignee <login>", async () => {
+    upsertIssue(db, makeIssue({ number: 1 }));
+    upsertIssue(db, makeIssue({ number: 2 }));
+    upsertAssignee(db, { id: 10, login: "carol", avatar_url: null });
+    linkIssueAssignee(db, 1, 10);
+    await cmdIssueList(makeDeps(["issue", "list", "--assignee", "carol"]));
+    expect(printed.some((l) => l.includes("#1"))).toBe(true);
+    expect(printed.some((l) => l.includes("#2"))).toBe(false);
+  });
+
+  test("--assignee @me は viewer_login に解決", async () => {
+    setSyncMeta(db, { viewer_login: "dave" });
+    upsertIssue(db, makeIssue({ number: 1 }));
+    upsertIssue(db, makeIssue({ number: 2 }));
+    upsertAssignee(db, { id: 11, login: "dave", avatar_url: null });
+    linkIssueAssignee(db, 2, 11);
+    await cmdIssueList(makeDeps(["issue", "list", "--assignee", "@me"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+
+  test("--label フィルタ", async () => {
+    upsertIssue(db, makeIssue({ number: 1 }));
+    upsertIssue(db, makeIssue({ number: 2 }));
+    upsertLabel(db, { id: 1, name: "bug", color: "red", description: null });
+    linkIssueLabel(db, 2, 1);
+    await cmdIssueList(makeDeps(["issue", "list", "--label", "bug"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+
+  test("--author フィルタ", async () => {
+    upsertIssue(db, makeIssue({ number: 1, author_login: "alice" }));
+    upsertIssue(db, makeIssue({ number: 2, author_login: "bob" }));
+    await cmdIssueList(makeDeps(["issue", "list", "--author", "bob"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+
+  test("空結果のとき empty メッセージ", async () => {
+    await cmdIssueList(makeDeps(["issue", "list"]));
+    // en: "(no issues / PRs matched)" / ja: "(該当する issue / PR はありません)" — 両方に含まれる語
+    expect(printed.join("\n")).toContain("issue");
+  });
+
+  test("--json で JSON 出力", async () => {
+    upsertIssue(db, makeIssue({ number: 1, title: "hello" }));
+    await cmdIssueList(makeDeps(["issue", "list", "--json", "number,title"]));
+    expect(printed.length).toBe(1);
+    const parsed = JSON.parse(printed[0]!);
+    expect(parsed).toEqual([{ number: 1, title: "hello" }]);
+  });
+
+  test("--json 空指定で全フィールド", async () => {
+    upsertIssue(db, makeIssue({ number: 1 }));
+    await cmdIssueList(makeDeps(["issue", "list", "--json", ""]));
+    const parsed = JSON.parse(printed[0]!);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].number).toBe(1);
+    expect(parsed[0].state).toBe("OPEN"); // gh-compat uppercase
+  });
+
+  test("--json author.login / assignees[].login", async () => {
+    upsertIssue(db, makeIssue({ number: 1 }));
+    upsertAssignee(db, { id: 10, login: "bob", avatar_url: null });
+    linkIssueAssignee(db, 1, 10);
+    await cmdIssueList(
+      makeDeps([
+        "issue",
+        "list",
+        "--json",
+        "number,author.login,assignees[].login",
+      ]),
+    );
+    const parsed = JSON.parse(printed[0]!);
+    expect(parsed[0]).toEqual({
+      number: 1,
+      author: "alice",
+      assignees: ["bob"],
+    });
+  });
+});
+
+describe("cmdPrList", () => {
+  test("PR のみ返る", async () => {
+    upsertIssue(db, makeIssue({ number: 1, type: "issue", state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, type: "pr", state: "open" }));
+    await cmdPrList(makeDeps(["pr", "list"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+
+  test("--state merged で merged PR のみ", async () => {
+    upsertIssue(db, makeIssue({ number: 1, type: "pr", state: "open" }));
+    upsertIssue(
+      db,
+      makeIssue({
+        number: 2,
+        type: "pr",
+        state: "closed",
+        merged_at: "2026-02-01T00:00:00Z",
+      }),
+    );
+    await cmdPrList(makeDeps(["pr", "list", "--state", "merged"]));
+    expect(printed.some((l) => l.includes("#2"))).toBe(true);
+    expect(printed.some((l) => l.includes("#1"))).toBe(false);
+  });
+});
+
+describe("cmdIssueShow", () => {
+  test("存在する issue を表示", async () => {
+    upsertIssue(db, makeIssue({ number: 7, title: "seven" }));
+    await cmdIssueShow(makeDeps(["issue", "show", "7"]), "issue");
+    const out = printed.join("\n");
+    expect(out).toContain("#7 seven");
+    expect(out).toContain("state:");
+    expect(out).toContain("hello");
+  });
+
+  test("存在しない番号で exit(1)", async () => {
+    const exitSpy = mock((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const origExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    try {
+      await expect(
+        cmdIssueShow(makeDeps(["issue", "show", "999"]), "issue"),
+      ).rejects.toThrow("exit 1");
+    } finally {
+      process.exit = origExit;
+    }
+  });
+
+  test("PR を issue show すると type mismatch エラー", async () => {
+    upsertIssue(db, makeIssue({ number: 5, type: "pr" }));
+    const exitSpy = mock((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const origExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    try {
+      await expect(
+        cmdIssueShow(makeDeps(["issue", "show", "5"]), "issue"),
+      ).rejects.toThrow("exit 1");
+    } finally {
+      process.exit = origExit;
+    }
+  });
+
+  test("--json で JSON 出力（gh-compat）", async () => {
+    upsertIssue(db, makeIssue({ number: 3, title: "three" }));
+    await cmdIssueShow(
+      makeDeps(["issue", "show", "3", "--json", "number,title,state"]),
+      "issue",
+    );
+    const parsed = JSON.parse(printed[0]!);
+    expect(parsed).toEqual({ number: 3, title: "three", state: "OPEN" });
+  });
+
+  test("数字以外の number で exit(1)", async () => {
+    const exitSpy = mock((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const origExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    try {
+      await expect(
+        cmdIssueShow(makeDeps(["issue", "show", "abc"]), "issue"),
+      ).rejects.toThrow("exit 1");
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});
+
+describe("cmdIssueSearch", () => {
+  test("title / body に LIKE マッチ", async () => {
+    upsertIssue(db, makeIssue({ number: 1, title: "alpha bug", body: "foo" }));
+    upsertIssue(db, makeIssue({ number: 2, title: "beta", body: "bug in body" }));
+    upsertIssue(db, makeIssue({ number: 3, title: "gamma", body: "none" }));
+    await cmdIssueSearch(makeDeps(["issue", "search", "bug"]));
+    const text = printed.join("\n");
+    expect(text).toContain("#1");
+    expect(text).toContain("#2");
+    expect(text).not.toContain("#3");
+  });
+
+  test("query 未指定で exit(1)", async () => {
+    const exitSpy = mock((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const origExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    try {
+      await expect(cmdIssueSearch(makeDeps(["issue", "search"]))).rejects.toThrow(
+        "exit 1",
+      );
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});
+
+describe("@me 解決失敗", () => {
+  test("viewer_login 未設定で --assignee @me は exit(1)", async () => {
+    const exitSpy = mock((code: number) => {
+      throw new Error(`exit ${code}`);
+    });
+    const origExit = process.exit;
+    process.exit = exitSpy as unknown as typeof process.exit;
+    try {
+      await expect(
+        cmdIssueList(makeDeps(["issue", "list", "--assignee", "@me"])),
+      ).rejects.toThrow("exit 1");
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-cli.ts
+++ b/skills/cmux-team/manager/gh-cache-cli.ts
@@ -1,0 +1,328 @@
+/**
+ * gh-cache-cli: `cmux-team issue …` / `cmux-team pr …` のハンドラ
+ *
+ * - `issue list` / `issue show` / `issue search`
+ * - `pr list` / `pr show`
+ *
+ * いずれもデフォルトはキャッシュ読み取り。`--sync` が付くと事前に
+ * incremental 同期を走らせる。`--stale-ok` 指定時はキャッシュの古さ警告を
+ * 抑止する（rate-limit 時や offline で有用）。
+ *
+ * Exit codes:
+ *   0 success
+ *   1 generic
+ *   2 non-git / non-GitHub
+ *   3 auth missing
+ *   4 rate limit exhausted
+ */
+import type { Database } from "bun:sqlite";
+import { t } from "./i18n";
+import { log } from "./logger";
+import {
+  listIssues,
+  searchIssues,
+  getIssue,
+  getIssueLabels,
+  getIssueAssignees,
+  getIssueComments,
+  getPrReviews,
+  getPrReviewComments,
+  getSyncMeta,
+  type IssueListFilter,
+} from "./gh-cache-store";
+import type {
+  IssueRow,
+  RepoInfo,
+  AuthResolution,
+} from "./gh-cache-types";
+import {
+  toGhJson,
+  pickGhFields,
+  formatIssueListRow,
+  formatIssueShow,
+  type IssueWithRelations,
+} from "./gh-cache-format";
+import { syncIncremental, RateLimitExhaustedError, SyncHttpError } from "./gh-cache-sync";
+
+const STALE_DAYS = 7;
+
+// --- 引数アクセスのヘルパ（main.ts の args 配列に対応）---
+
+function getFlagValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function hasBareFlag(args: string[], name: string): boolean {
+  return args.includes(`--${name}`);
+}
+
+/** `--limit N` を整数化（不正値は 30） */
+function parseLimit(args: string[]): number {
+  const raw = getFlagValue(args, "limit");
+  if (!raw) return 30;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 30;
+  return Math.min(Math.floor(n), 1000);
+}
+
+/** `--state open|closed|merged|all` → IssueListFilter.state */
+function parseState(
+  args: string[],
+  defaultValue: "open" | "closed" | "merged" | "all" = "open",
+): "open" | "closed" | "merged" | "all" {
+  const raw = getFlagValue(args, "state");
+  if (!raw) return defaultValue;
+  const v = raw.toLowerCase();
+  if (v === "open" || v === "closed" || v === "merged" || v === "all") return v;
+  return defaultValue;
+}
+
+// --- 依存性（main.ts 側から注入される）---
+
+export interface GhContext {
+  db: Database;
+  repoInfo: RepoInfo;
+  auth: AuthResolution & { token: string };
+}
+
+export interface CliDeps extends GhContext {
+  args: string[];
+  fetchFn?: typeof fetch; // テスト用 DI
+  stdout?: (s: string) => void;
+}
+
+function print(deps: CliDeps, s: string): void {
+  (deps.stdout ?? console.log)(s);
+}
+
+/** キャッシュが stale（最終 full sync から STALE_DAYS 日以上）なら警告を出す */
+function maybeWarnStale(deps: CliDeps): void {
+  if (hasBareFlag(deps.args, "stale-ok")) return;
+  const meta = getSyncMeta(deps.db);
+  if (!meta?.last_full_sync) return;
+  const then = Date.parse(meta.last_full_sync);
+  if (!Number.isFinite(then)) return;
+  const days = Math.floor((Date.now() - then) / (24 * 3600 * 1000));
+  if (days >= STALE_DAYS) {
+    console.error(t("gh_stale_warning", { days: String(days) }));
+  }
+}
+
+/**
+ * `--assignee @me` を `sync_meta.viewer_login` に解決する。
+ * 解決できない場合は exit 1（@me を使うなら sync を先に実行する必要がある）。
+ */
+function resolveAssignee(deps: CliDeps): string | undefined {
+  const raw = getFlagValue(deps.args, "assignee");
+  if (!raw) return undefined;
+  if (raw === "@me") {
+    const meta = getSyncMeta(deps.db);
+    if (!meta?.viewer_login) {
+      console.error(t("gh_me_not_resolved"));
+      process.exit(1);
+    }
+    return meta.viewer_login;
+  }
+  // `@login` の先頭 @ は取り除く
+  return raw.startsWith("@") ? raw.slice(1) : raw;
+}
+
+/** 同じく `--author @me` を解決する */
+function resolveAuthor(deps: CliDeps): string | undefined {
+  const raw = getFlagValue(deps.args, "author");
+  if (!raw) return undefined;
+  if (raw === "@me") {
+    const meta = getSyncMeta(deps.db);
+    if (!meta?.viewer_login) {
+      console.error(t("gh_me_not_resolved"));
+      process.exit(1);
+    }
+    return meta.viewer_login;
+  }
+  return raw.startsWith("@") ? raw.slice(1) : raw;
+}
+
+/** `--sync` フラグが立っていれば事前に incremental sync を走らせる */
+async function maybeSync(deps: CliDeps): Promise<void> {
+  if (!hasBareFlag(deps.args, "sync")) return;
+  try {
+    await syncIncremental({
+      db: deps.db,
+      repoInfo: deps.repoInfo,
+      auth: deps.auth,
+      fetchFn: deps.fetchFn,
+    });
+  } catch (e) {
+    if (e instanceof RateLimitExhaustedError) {
+      console.error(
+        t("gh_rate_limit_exhausted", {
+          remaining: String(e.rateLimit.remaining ?? "?"),
+          reset_at: e.rateLimit.resetAt ?? "?",
+        }),
+      );
+      process.exit(4);
+    }
+    if (e instanceof SyncHttpError) {
+      console.error(`Error: GitHub API ${e.status}: ${e.message}`);
+      process.exit(1);
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    log("error", `gh_cli_sync_failed: ${msg}`);
+    // sync 失敗時はキャッシュ読み取りにフォールバック
+    console.error(`Warning: sync failed, reading from cache: ${msg}`);
+  }
+}
+
+// --- issue list / show / search ---
+
+/**
+ * `cmux-team issue list [--state open|closed|merged|all] [--assignee @me]
+ *                      [--author <name>] [--label <name>] [--limit 30]
+ *                      [--json FIELDS] [--sync] [--stale-ok]`
+ *
+ * - `issue` type のみ（PR は除外）
+ * - デフォルト state=open
+ */
+export async function cmdIssueList(deps: CliDeps): Promise<void> {
+  await maybeSync(deps);
+  maybeWarnStale(deps);
+
+  const filter: IssueListFilter = {
+    type: "issue",
+    state: parseState(deps.args, "open"),
+    assigneeLogin: resolveAssignee(deps),
+    authorLogin: resolveAuthor(deps),
+    labelName: getFlagValue(deps.args, "label"),
+    limit: parseLimit(deps.args),
+  };
+  const rows = listIssues(deps.db, filter);
+  printIssueList(deps, rows);
+}
+
+/** `cmux-team pr list ...` (type="pr") */
+export async function cmdPrList(deps: CliDeps): Promise<void> {
+  await maybeSync(deps);
+  maybeWarnStale(deps);
+
+  const filter: IssueListFilter = {
+    type: "pr",
+    state: parseState(deps.args, "open"),
+    assigneeLogin: resolveAssignee(deps),
+    authorLogin: resolveAuthor(deps),
+    labelName: getFlagValue(deps.args, "label"),
+    limit: parseLimit(deps.args),
+  };
+  const rows = listIssues(deps.db, filter);
+  printIssueList(deps, rows);
+}
+
+function printIssueList(deps: CliDeps, rows: IssueRow[]): void {
+  const jsonFields = getFlagValue(deps.args, "json");
+
+  if (jsonFields !== undefined) {
+    const fields = jsonFields.split(",").map((s) => s.trim()).filter((s) => s);
+    const out = rows.map((r) => {
+      const labels = getIssueLabels(deps.db, r.number);
+      const assignees = getIssueAssignees(deps.db, r.number);
+      const full = toGhJson({ issue: r, labels, assignees });
+      return fields.length > 0 ? pickGhFields(full, fields) : full;
+    });
+    print(deps, JSON.stringify(out, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    print(deps, t("gh_issue_empty"));
+    return;
+  }
+  for (const r of rows) {
+    const labels = getIssueLabels(deps.db, r.number);
+    const assignees = getIssueAssignees(deps.db, r.number);
+    print(deps, formatIssueListRow({ issue: r, labels, assignees }));
+  }
+}
+
+/**
+ * `cmux-team issue show <N> [--json FIELDS] [--sync]`
+ * `cmux-team pr show <N> [--json FIELDS] [--sync]`
+ *
+ * 両者で同じ処理（PR は reviews / review_comments を追加で付ける）。
+ */
+export async function cmdIssueShow(deps: CliDeps, kind: "issue" | "pr"): Promise<void> {
+  const numRaw = deps.args[2]; // `issue show <N>` or `pr show <N>`
+  if (!numRaw) {
+    console.error(
+      kind === "issue"
+        ? "Usage: cmux-team issue show <number>"
+        : "Usage: cmux-team pr show <number>",
+    );
+    process.exit(1);
+  }
+  const number = Number(numRaw);
+  if (!Number.isInteger(number) || number <= 0) {
+    console.error(`Error: invalid number: ${numRaw}`);
+    process.exit(1);
+  }
+
+  await maybeSync(deps);
+  maybeWarnStale(deps);
+
+  const issue = getIssue(deps.db, number);
+  if (!issue) {
+    console.error(t("gh_cache_not_initialized"));
+    process.exit(1);
+  }
+  // kind が指定されたら type が一致しているか検証（不一致なら cache miss 扱い）
+  if (issue.type !== kind) {
+    console.error(
+      `Error: #${number} is a ${issue.type}, not ${kind}. Try 'cmux-team ${issue.type} show ${number}'.`,
+    );
+    process.exit(1);
+  }
+
+  const labels = getIssueLabels(deps.db, number);
+  const assignees = getIssueAssignees(deps.db, number);
+  const comments = getIssueComments(deps.db, number);
+  const rel: IssueWithRelations = { issue, labels, assignees, comments };
+  if (kind === "pr") {
+    rel.reviews = getPrReviews(deps.db, number);
+    rel.reviewComments = getPrReviewComments(deps.db, number);
+  }
+
+  const jsonFields = getFlagValue(deps.args, "json");
+  if (jsonFields !== undefined) {
+    const fields = jsonFields.split(",").map((s) => s.trim()).filter((s) => s);
+    const full = toGhJson(rel);
+    const out = fields.length > 0 ? pickGhFields(full, fields) : full;
+    print(deps, JSON.stringify(out, null, 2));
+    return;
+  }
+
+  print(deps, formatIssueShow(rel));
+}
+
+/**
+ * `cmux-team issue search <query> [--state ...] [--limit 30] [--json FIELDS]`
+ *
+ * キャッシュ内 LIKE 検索（title + body）。`--sync` で事前に incremental を
+ * 走らせられるが、キャッシュにない issue はヒットしない（そもそも未取得）。
+ */
+export async function cmdIssueSearch(deps: CliDeps): Promise<void> {
+  const query = deps.args[2];
+  if (!query) {
+    console.error("Usage: cmux-team issue search <query>");
+    process.exit(1);
+  }
+
+  await maybeSync(deps);
+  maybeWarnStale(deps);
+
+  const filter: IssueListFilter = {
+    type: "issue",
+    state: parseState(deps.args, "all"),
+    limit: parseLimit(deps.args),
+  };
+  const rows = searchIssues(deps.db, query, filter);
+  printIssueList(deps, rows);
+}

--- a/skills/cmux-team/manager/gh-cache-format.test.ts
+++ b/skills/cmux-team/manager/gh-cache-format.test.ts
@@ -1,0 +1,338 @@
+import { describe, test, expect } from "bun:test";
+import {
+  toGhJson,
+  normalizeGhState,
+  pickGhFields,
+  formatIssueListRow,
+  formatIssueShow,
+  displayState,
+} from "./gh-cache-format";
+import type {
+  IssueRow,
+  LabelRow,
+  AssigneeRow,
+  CommentRow,
+  ReviewRow,
+  ReviewCommentRow,
+} from "./gh-cache-types";
+
+function makeIssue(overrides: Partial<IssueRow> = {}): IssueRow {
+  return {
+    number: 1,
+    type: "issue",
+    state: "open",
+    title: "hello",
+    body: "body text",
+    author_login: "alice",
+    author_id: 100,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    html_url: "https://github.com/acme/widget/issues/1",
+    comments_count: 0,
+    milestone_id: null,
+    draft: null,
+    etag: null,
+    fetched_at: "2026-01-03T00:00:00Z",
+    raw_json: null,
+    ...overrides,
+  };
+}
+
+function label(id: number, name: string): LabelRow {
+  return { id, name, color: "ff0000", description: null };
+}
+function assignee(id: number, login: string): AssigneeRow {
+  return { id, login, avatar_url: null };
+}
+
+describe("normalizeGhState", () => {
+  test("issue の state は大文字化", () => {
+    expect(normalizeGhState(makeIssue({ state: "open" }))).toBe("OPEN");
+    expect(normalizeGhState(makeIssue({ state: "closed" }))).toBe("CLOSED");
+  });
+
+  test("PR + merged_at が立つと MERGED", () => {
+    expect(
+      normalizeGhState(
+        makeIssue({ type: "pr", state: "closed", merged_at: "2026-02-01T00:00:00Z" }),
+      ),
+    ).toBe("MERGED");
+  });
+
+  test("PR + merged_at が null なら state を大文字化", () => {
+    expect(
+      normalizeGhState(makeIssue({ type: "pr", state: "open", merged_at: null })),
+    ).toBe("OPEN");
+  });
+});
+
+describe("toGhJson", () => {
+  test("issue の基本フィールド", () => {
+    const obj = toGhJson({
+      issue: makeIssue(),
+      labels: [label(1, "bug")],
+      assignees: [assignee(2, "bob")],
+    });
+    expect(obj).toMatchObject({
+      number: 1,
+      title: "hello",
+      body: "body text",
+      state: "OPEN",
+      author: { login: "alice" },
+      assignees: [{ login: "bob" }],
+      labels: [{ name: "bug", color: "ff0000" }],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      closedAt: null,
+      url: "https://github.com/acme/widget/issues/1",
+      isPullRequest: false,
+      commentsCount: 0,
+    });
+    expect(obj.mergedAt).toBeUndefined();
+    expect(obj.isDraft).toBeUndefined();
+  });
+
+  test("PR 専用フィールド (mergedAt / isDraft)", () => {
+    const obj = toGhJson({
+      issue: makeIssue({ type: "pr", merged_at: "2026-02-01T00:00:00Z", draft: 1 }),
+      labels: [],
+      assignees: [],
+    });
+    expect(obj.isPullRequest).toBe(true);
+    expect(obj.state).toBe("MERGED");
+    expect(obj.mergedAt).toBe("2026-02-01T00:00:00Z");
+    expect(obj.isDraft).toBe(true);
+  });
+
+  test("author が null の issue", () => {
+    const obj = toGhJson({
+      issue: makeIssue({ author_login: null, author_id: null }),
+      labels: [],
+      assignees: [],
+    });
+    expect(obj.author).toBeNull();
+  });
+
+  test("comments を含めると配列として入る", () => {
+    const comments: CommentRow[] = [
+      {
+        id: 10,
+        issue_number: 1,
+        author_login: "bob",
+        body: "hi",
+        created_at: "2026-01-03T00:00:00Z",
+        updated_at: "2026-01-03T00:00:00Z",
+        html_url: null,
+        raw_json: null,
+      },
+    ];
+    const obj = toGhJson({
+      issue: makeIssue(),
+      labels: [],
+      assignees: [],
+      comments,
+    });
+    expect(Array.isArray(obj.comments)).toBe(true);
+    expect((obj.comments as unknown[])[0]).toMatchObject({
+      author: { login: "bob" },
+      body: "hi",
+      createdAt: "2026-01-03T00:00:00Z",
+    });
+  });
+
+  test("reviews / reviewComments を含める", () => {
+    const reviews: ReviewRow[] = [
+      {
+        id: 20,
+        pr_number: 1,
+        author_login: "reviewer",
+        state: "approved",
+        body: "lgtm",
+        submitted_at: "2026-01-04T00:00:00Z",
+        raw_json: null,
+      },
+    ];
+    const reviewComments: ReviewCommentRow[] = [
+      {
+        id: 30,
+        pr_number: 1,
+        review_id: 20,
+        author_login: "reviewer",
+        body: "nit",
+        path: "src/index.ts",
+        line: 42,
+        original_line: null,
+        commit_id: null,
+        created_at: "2026-01-04T00:00:00Z",
+        updated_at: "2026-01-04T00:00:00Z",
+        raw_json: null,
+      },
+    ];
+    const obj = toGhJson({
+      issue: makeIssue({ type: "pr" }),
+      labels: [],
+      assignees: [],
+      reviews,
+      reviewComments,
+    });
+    expect((obj.reviews as unknown[])[0]).toMatchObject({
+      state: "APPROVED",
+      body: "lgtm",
+      author: { login: "reviewer" },
+    });
+    expect((obj.reviewComments as unknown[])[0]).toMatchObject({
+      body: "nit",
+      path: "src/index.ts",
+      line: 42,
+    });
+  });
+});
+
+describe("pickGhFields", () => {
+  const source = {
+    number: 1,
+    title: "hello",
+    author: { login: "alice" },
+    assignees: [{ login: "bob" }, { login: "carol" }],
+    labels: [{ name: "bug", color: "red" }],
+    nested: { deep: { val: 42 } },
+  };
+
+  test("単純プロパティ", () => {
+    expect(pickGhFields(source, ["number", "title"])).toEqual({
+      number: 1,
+      title: "hello",
+    });
+  });
+
+  test("ドットパス (author.login)", () => {
+    expect(pickGhFields(source, ["author.login"])).toEqual({
+      author: "alice",
+    });
+  });
+
+  test("配列マップ (assignees[].login)", () => {
+    expect(pickGhFields(source, ["assignees[].login"])).toEqual({
+      assignees: ["bob", "carol"],
+    });
+  });
+
+  test("ネストしたドットパス (nested.deep.val)", () => {
+    expect(pickGhFields(source, ["nested.deep.val"])).toEqual({
+      nested: 42,
+    });
+  });
+
+  test("未知フィールドは無視", () => {
+    expect(pickGhFields(source, ["unknown", "number"])).toEqual({
+      number: 1,
+    });
+  });
+
+  test("空文字やスペースは無視", () => {
+    expect(pickGhFields(source, ["", " ", "number"])).toEqual({
+      number: 1,
+    });
+  });
+
+  test("複数混在", () => {
+    expect(
+      pickGhFields(source, [
+        "number",
+        "author.login",
+        "assignees[].login",
+        "labels[].name",
+      ]),
+    ).toEqual({
+      number: 1,
+      author: "alice",
+      assignees: ["bob", "carol"],
+      labels: ["bug"],
+    });
+  });
+});
+
+describe("formatIssueListRow", () => {
+  test("open issue with label + assignee", () => {
+    const out = formatIssueListRow({
+      issue: makeIssue({ number: 42, title: "bug fix" }),
+      labels: [label(1, "bug")],
+      assignees: [assignee(2, "bob")],
+    });
+    expect(out).toContain("#42");
+    expect(out).toContain("open");
+    expect(out).toContain("bug fix");
+    expect(out).toContain("[bug]");
+    expect(out).toContain("(@bob)");
+  });
+
+  test("merged PR state displayed as merged", () => {
+    const out = formatIssueListRow({
+      issue: makeIssue({
+        number: 3,
+        type: "pr",
+        state: "closed",
+        merged_at: "2026-02-01T00:00:00Z",
+        title: "feat",
+      }),
+      labels: [],
+      assignees: [],
+    });
+    expect(out).toContain("merged");
+    expect(out).not.toContain("[");
+    expect(out).not.toContain("(@");
+  });
+});
+
+describe("displayState", () => {
+  test("open / closed / merged", () => {
+    expect(displayState(makeIssue({ state: "open" }))).toBe("open");
+    expect(displayState(makeIssue({ state: "closed" }))).toBe("closed");
+    expect(
+      displayState(
+        makeIssue({ type: "pr", state: "closed", merged_at: "2026-02-01T00:00:00Z" }),
+      ),
+    ).toBe("merged");
+  });
+});
+
+describe("formatIssueShow", () => {
+  test("本文と labels / assignees を含む", () => {
+    const out = formatIssueShow({
+      issue: makeIssue({ title: "first" }),
+      labels: [label(1, "bug")],
+      assignees: [assignee(2, "bob")],
+    });
+    expect(out).toContain("#1 first");
+    expect(out).toContain("state:     open");
+    expect(out).toContain("author:    @alice");
+    expect(out).toContain("labels:    bug");
+    expect(out).toContain("assignees: @bob");
+    expect(out).toContain("body text");
+  });
+
+  test("comments セクション", () => {
+    const out = formatIssueShow({
+      issue: makeIssue(),
+      labels: [],
+      assignees: [],
+      comments: [
+        {
+          id: 1,
+          issue_number: 1,
+          author_login: "bob",
+          body: "hi there",
+          created_at: "2026-01-03T00:00:00Z",
+          updated_at: "2026-01-03T00:00:00Z",
+          html_url: null,
+          raw_json: null,
+        },
+      ],
+    });
+    expect(out).toContain("── comments ──");
+    expect(out).toContain("@bob");
+    expect(out).toContain("hi there");
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-format.ts
+++ b/skills/cmux-team/manager/gh-cache-format.ts
@@ -1,0 +1,241 @@
+/**
+ * gh-cache-format: gh CLI 互換の JSON 整形 + 表示整形
+ *
+ * `cmux-team issue list --json number,title,author.login` のような
+ * フィールド指定（gh CLI 互換）をサポートする。
+ *
+ * - state は gh CLI 互換で大文字（`OPEN` / `CLOSED` / `MERGED`）
+ * - author は `{ login }`、assignees は `[{ login }]`、labels は `[{ name }]`
+ * - 日付キーは `createdAt` / `updatedAt` / `closedAt` / `mergedAt`（camelCase）
+ *
+ * **注意:** `--json` なしのテキスト出力側（list / show）では state は小文字のまま。
+ */
+import type {
+  IssueRow,
+  LabelRow,
+  AssigneeRow,
+  CommentRow,
+  ReviewRow,
+  ReviewCommentRow,
+} from "./gh-cache-types";
+
+export interface IssueWithRelations {
+  issue: IssueRow;
+  labels: LabelRow[];
+  assignees: AssigneeRow[];
+  comments?: CommentRow[];
+  reviews?: ReviewRow[];
+  reviewComments?: ReviewCommentRow[];
+}
+
+/** gh-compat JSON 用の完全オブジェクトを組み立てる */
+export function toGhJson(rel: IssueWithRelations): Record<string, unknown> {
+  const { issue, labels, assignees, comments, reviews, reviewComments } = rel;
+  const state = normalizeGhState(issue);
+  const obj: Record<string, unknown> = {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? "",
+    state,
+    author: issue.author_login ? { login: issue.author_login } : null,
+    assignees: assignees.map((a) => ({ login: a.login })),
+    labels: labels.map((l) => ({ name: l.name, color: l.color ?? "" })),
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    closedAt: issue.closed_at,
+    url: issue.html_url,
+    isPullRequest: issue.type === "pr",
+    commentsCount: issue.comments_count,
+  };
+  if (issue.type === "pr") {
+    obj.mergedAt = issue.merged_at;
+    obj.isDraft = issue.draft === 1 ? true : issue.draft === 0 ? false : null;
+  }
+  if (comments) {
+    obj.comments = comments.map((c) => ({
+      author: c.author_login ? { login: c.author_login } : null,
+      body: c.body,
+      createdAt: c.created_at,
+      updatedAt: c.updated_at,
+    }));
+  }
+  if (reviews) {
+    obj.reviews = reviews.map((r) => ({
+      author: r.author_login ? { login: r.author_login } : null,
+      state: r.state.toUpperCase(),
+      body: r.body ?? "",
+      submittedAt: r.submitted_at,
+    }));
+  }
+  if (reviewComments) {
+    obj.reviewComments = reviewComments.map((rc) => ({
+      author: rc.author_login ? { login: rc.author_login } : null,
+      body: rc.body,
+      path: rc.path,
+      line: rc.line ?? rc.original_line,
+      createdAt: rc.created_at,
+      updatedAt: rc.updated_at,
+    }));
+  }
+  return obj;
+}
+
+/**
+ * issue の state を gh CLI 互換の大文字ラベルに正規化する。
+ * - PR で `merged_at` が立っていれば `MERGED`
+ * - それ以外は `state` を大文字化
+ */
+export function normalizeGhState(issue: IssueRow): string {
+  if (issue.type === "pr" && issue.merged_at) return "MERGED";
+  return (issue.state ?? "").toUpperCase();
+}
+
+/**
+ * gh CLI 互換のフィールド指定（`number,title,author.login,assignees[].login`）で
+ * JSON オブジェクトをサブセット化する。
+ *
+ * - `foo.bar` はドットパス（オブジェクト展開）
+ * - `foo[].bar` は配列要素のマップ
+ * - 未知フィールドは無視（空 object にならないよう null ではなく欠落）
+ */
+export function pickGhFields(
+  source: Record<string, unknown>,
+  fields: string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    const normalized = f.trim();
+    if (!normalized) continue;
+    const value = resolveGhField(source, normalized);
+    if (value === undefined) continue;
+    // gh CLI は出力キーとして top-level フィールド名を使う（foo.bar → foo）
+    const topKey = normalized.split(/[.\[]/)[0]!;
+    out[topKey] = value;
+  }
+  return out;
+}
+
+/**
+ * `author.login` / `assignees[].login` 等の path を解決する。
+ * 配列要素のマップは `[].rest` で表現する（gh CLI に倣う）。
+ */
+function resolveGhField(root: unknown, path: string): unknown {
+  // まず top-level を取得し、残りのパスを再帰的に辿る
+  const firstDot = path.indexOf(".");
+  const firstBracket = path.indexOf("[]");
+  // セパレータが無ければ top-level のプロパティ
+  if (firstDot < 0 && firstBracket < 0) {
+    return getProp(root, path);
+  }
+  // 最初に現れたセパレータで分割
+  const sep =
+    firstBracket < 0 || (firstDot >= 0 && firstDot < firstBracket)
+      ? { pos: firstDot, kind: "dot" as const }
+      : { pos: firstBracket, kind: "bracket" as const };
+  const head = path.slice(0, sep.pos);
+  const tail = sep.kind === "dot" ? path.slice(sep.pos + 1) : path.slice(sep.pos + 2);
+  const headValue = getProp(root, head);
+  if (headValue === undefined || headValue === null) return headValue;
+
+  if (sep.kind === "bracket") {
+    if (!Array.isArray(headValue)) return undefined;
+    // `.rest` の先頭ドットを取り除く
+    const rest = tail.startsWith(".") ? tail.slice(1) : tail;
+    if (!rest) return headValue;
+    return headValue.map((item) => resolveGhField(item, rest));
+  }
+  // dot
+  return resolveGhField(headValue, tail);
+}
+
+function getProp(value: unknown, key: string): unknown {
+  if (value === null || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+// --- テキスト出力（list 向け）---
+
+export interface IssueListRow {
+  issue: IssueRow;
+  labels: LabelRow[];
+  assignees: AssigneeRow[];
+}
+
+/**
+ * `cmux-team issue list` のテキスト出力（3 列固定幅）:
+ *   #NUMBER  STATE  TITLE  [labels]  (@assignees)
+ *
+ * - NUMBER は右寄せ 5 桁
+ * - STATE は 6 桁左寄せ（open / closed / merged）
+ * - 末尾に labels / assignees を付ける（空なら省略）
+ */
+export function formatIssueListRow(row: IssueListRow): string {
+  const { issue, labels, assignees } = row;
+  const num = `#${issue.number}`.padStart(6);
+  const state = displayState(issue).padEnd(7);
+  const parts: string[] = [num, state, issue.title];
+  if (labels.length > 0) {
+    parts.push(`[${labels.map((l) => l.name).join(", ")}]`);
+  }
+  if (assignees.length > 0) {
+    parts.push(`(@${assignees.map((a) => a.login).join(", @")})`);
+  }
+  return parts.join("  ");
+}
+
+/** `open` / `closed` / `merged` のテキスト表示用 state */
+export function displayState(issue: IssueRow): string {
+  if (issue.type === "pr" && issue.merged_at) return "merged";
+  return issue.state ?? "";
+}
+
+/** `cmux-team issue show` のテキスト出力 */
+export function formatIssueShow(rel: IssueWithRelations): string {
+  const { issue, labels, assignees, comments, reviews, reviewComments } = rel;
+  const lines: string[] = [];
+  lines.push(`#${issue.number} ${issue.title}`);
+  lines.push(`state:     ${displayState(issue)}`);
+  lines.push(`author:    @${issue.author_login ?? "-"}`);
+  lines.push(`created:   ${issue.created_at}`);
+  lines.push(`updated:   ${issue.updated_at}`);
+  if (issue.closed_at) lines.push(`closed:    ${issue.closed_at}`);
+  if (issue.merged_at) lines.push(`merged:    ${issue.merged_at}`);
+  if (labels.length > 0) {
+    lines.push(`labels:    ${labels.map((l) => l.name).join(", ")}`);
+  }
+  if (assignees.length > 0) {
+    lines.push(`assignees: ${assignees.map((a) => `@${a.login}`).join(", ")}`);
+  }
+  lines.push(`url:       ${issue.html_url}`);
+  lines.push("");
+  lines.push(issue.body ?? "");
+  if (comments && comments.length > 0) {
+    lines.push("");
+    lines.push("── comments ──");
+    for (const c of comments) {
+      lines.push("");
+      lines.push(`@${c.author_login ?? "-"}  ${c.created_at}`);
+      lines.push(c.body);
+    }
+  }
+  if (reviews && reviews.length > 0) {
+    lines.push("");
+    lines.push("── reviews ──");
+    for (const r of reviews) {
+      lines.push("");
+      lines.push(`@${r.author_login ?? "-"}  ${r.state}  ${r.submitted_at ?? ""}`);
+      if (r.body) lines.push(r.body);
+    }
+  }
+  if (reviewComments && reviewComments.length > 0) {
+    lines.push("");
+    lines.push("── review comments ──");
+    for (const rc of reviewComments) {
+      lines.push("");
+      const loc = rc.path ? `${rc.path}:${rc.line ?? rc.original_line ?? "?"}` : "";
+      lines.push(`@${rc.author_login ?? "-"}  ${loc}  ${rc.created_at}`);
+      lines.push(rc.body);
+    }
+  }
+  return lines.join("\n");
+}

--- a/skills/cmux-team/manager/gh-cache-repo.test.ts
+++ b/skills/cmux-team/manager/gh-cache-repo.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "bun:test";
+import { parseRemoteUrl, apiBaseUrl } from "./gh-cache-repo";
+
+describe("parseRemoteUrl", () => {
+  test("github.com SSH", () => {
+    expect(parseRemoteUrl("git@github.com:owner/repo.git")).toEqual({
+      host: "api.github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  test("github.com HTTPS with .git", () => {
+    expect(parseRemoteUrl("https://github.com/owner/repo.git")).toEqual({
+      host: "api.github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  test("github.com HTTPS without .git", () => {
+    expect(parseRemoteUrl("https://github.com/owner/repo")).toEqual({
+      host: "api.github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  test("GHE SSH → host includes /api/v3", () => {
+    expect(parseRemoteUrl("git@ghe.example.com:o/r.git")).toEqual({
+      host: "ghe.example.com/api/v3",
+      owner: "o",
+      repo: "r",
+    });
+  });
+
+  test("GHE HTTPS → host includes /api/v3", () => {
+    expect(parseRemoteUrl("https://ghe.example.com/o/r")).toEqual({
+      host: "ghe.example.com/api/v3",
+      owner: "o",
+      repo: "r",
+    });
+  });
+
+  test("gitlab.com → null", () => {
+    expect(parseRemoteUrl("git@gitlab.com:o/r.git")).toBeNull();
+  });
+
+  test("bitbucket.org → null", () => {
+    expect(parseRemoteUrl("https://bitbucket.org/o/r.git")).toBeNull();
+  });
+
+  test("empty string → null", () => {
+    expect(parseRemoteUrl("")).toBeNull();
+  });
+
+  test("invalid URL → null", () => {
+    expect(parseRemoteUrl("not a url")).toBeNull();
+  });
+
+  test("ssh:// URL 形式", () => {
+    expect(parseRemoteUrl("ssh://git@github.com/owner/repo.git")).toEqual({
+      host: "api.github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  test("www.github.com も normalize される", () => {
+    expect(parseRemoteUrl("https://www.github.com/owner/repo")).toEqual({
+      host: "api.github.com",
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+});
+
+describe("apiBaseUrl", () => {
+  test("api.github.com", () => {
+    expect(apiBaseUrl("api.github.com")).toBe("https://api.github.com");
+  });
+
+  test("GHE host with /api/v3", () => {
+    expect(apiBaseUrl("ghe.example.com/api/v3")).toBe(
+      "https://ghe.example.com/api/v3",
+    );
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-repo.ts
+++ b/skills/cmux-team/manager/gh-cache-repo.ts
@@ -1,0 +1,97 @@
+/**
+ * gh-cache: git remote から {host, owner, repo} を解決する。
+ *
+ * - `git@github.com:o/r.git` → host=api.github.com
+ * - `https://github.com/o/r(.git)` → host=api.github.com
+ * - `git@ghe.example.com:o/r.git` → host=ghe.example.com/api/v3
+ * - `https://ghe.example.com/o/r(.git)` → host=ghe.example.com/api/v3
+ * - GitLab / bitbucket / 非 GitHub → null
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { existsSync } from "fs";
+import { join } from "path";
+import type { RepoInfo } from "./gh-cache-types";
+
+const execFileAsync = promisify(execFile);
+
+/** `cwd` が git repo 内かどうかの判定（.git ディレクトリ or ファイル、worktree 対応） */
+export function isGitRepo(cwd: string): boolean {
+  let dir = cwd;
+  for (let i = 0; i < 32; i++) {
+    if (existsSync(join(dir, ".git"))) return true;
+    const parent = join(dir, "..");
+    if (parent === dir) return false;
+    dir = parent;
+  }
+  return false;
+}
+
+/**
+ * `git remote get-url origin` の出力から RepoInfo を組み立てる。
+ *
+ * 純粋関数。テスト用に URL 直渡しで呼べるようにしておく。
+ */
+export function parseRemoteUrl(url: string): RepoInfo | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  // SSH: git@host:owner/repo(.git)
+  const sshMatch = trimmed.match(/^[\w.-]+@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch && sshMatch[1] && sshMatch[2] && sshMatch[3]) {
+    return buildRepoInfo(sshMatch[1], sshMatch[2], sshMatch[3]);
+  }
+
+  // HTTPS: https://host/owner/repo(.git) or http://
+  const httpsMatch = trimmed.match(/^https?:\/\/(?:[^@/]+@)?([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (httpsMatch && httpsMatch[1] && httpsMatch[2] && httpsMatch[3]) {
+    return buildRepoInfo(httpsMatch[1], httpsMatch[2], httpsMatch[3]);
+  }
+
+  // git:// や ssh:// 形式（まれ）
+  const sshUrlMatch = trimmed.match(/^(?:ssh|git):\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+  if (sshUrlMatch && sshUrlMatch[1] && sshUrlMatch[2] && sshUrlMatch[3]) {
+    return buildRepoInfo(sshUrlMatch[1], sshUrlMatch[2], sshUrlMatch[3]);
+  }
+
+  return null;
+}
+
+function buildRepoInfo(hostRaw: string, owner: string, repo: string): RepoInfo | null {
+  const host = hostRaw.toLowerCase();
+  if (host === "github.com" || host === "www.github.com") {
+    return { host: "api.github.com", owner, repo };
+  }
+  // GHE と仮定: gitlab.com / bitbucket.org / その他は除外
+  if (host === "gitlab.com" || host === "www.gitlab.com") return null;
+  if (host === "bitbucket.org" || host === "www.bitbucket.org") return null;
+  if (host === "codeberg.org") return null;
+  if (host === "git.sr.ht" || host === "sr.ht") return null;
+  // GHE 扱い: ホスト名に "github" が含まれる / それ以外は GHE と仮定
+  // 実運用上は「GitHub でない remote は非 GitHub」だが、企業 GHE はホスト名が
+  // 任意なので「除外 list 方式」で判定する（plan §4 の host 判定方針）。
+  return { host: `${host}/api/v3`, owner, repo };
+}
+
+/**
+ * `git remote get-url origin` を実行して解決する。
+ * 非 git / origin 未設定 / 非 GitHub の場合は null を返す。
+ */
+export async function resolveOriginRepo(cwd: string): Promise<RepoInfo | null> {
+  if (!isGitRepo(cwd)) return null;
+  try {
+    const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd });
+    return parseRemoteUrl(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * REST API の base URL を返す（末尾スラッシュなし）。
+ * - "api.github.com" → "https://api.github.com"
+ * - "ghe.example.com/api/v3" → "https://ghe.example.com/api/v3"
+ */
+export function apiBaseUrl(host: string): string {
+  return `https://${host}`;
+}

--- a/skills/cmux-team/manager/gh-cache-store.test.ts
+++ b/skills/cmux-team/manager/gh-cache-store.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openGhCacheDB,
+  upsertIssue,
+  upsertComment,
+  upsertLabel,
+  upsertAssignee,
+  linkIssueLabel,
+  linkIssueAssignee,
+  clearIssueLabels,
+  clearIssueAssignees,
+  getSyncMeta,
+  setSyncMeta,
+  getCacheStats,
+  listIssues,
+  getIssue,
+  getIssueLabels,
+  getIssueAssignees,
+} from "./gh-cache-store";
+import type { IssueRow, RepoInfo } from "./gh-cache-types";
+
+const REPO: RepoInfo = {
+  host: "api.github.com",
+  owner: "acme",
+  repo: "widget",
+};
+const TOKEN_HASH = "a".repeat(32);
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "gh-cache-store-test-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function makeIssue(overrides: Partial<IssueRow> = {}): IssueRow {
+  return {
+    number: 1,
+    type: "issue",
+    state: "open",
+    title: "sample",
+    body: "hello",
+    author_login: "alice",
+    author_id: 100,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    merged_at: null,
+    html_url: "https://github.com/acme/widget/issues/1",
+    comments_count: 0,
+    milestone_id: null,
+    draft: null,
+    etag: null,
+    fetched_at: "2026-01-03T00:00:00Z",
+    raw_json: null,
+    ...overrides,
+  };
+}
+
+describe("openGhCacheDB", () => {
+  test("新規作成時 sync_meta に repo 情報が入る", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    const meta = getSyncMeta(db);
+    expect(meta).toBeDefined();
+    expect(meta!.token_hash).toBe(TOKEN_HASH);
+    expect(meta!.host).toBe("api.github.com");
+    expect(meta!.owner).toBe("acme");
+    expect(meta!.repo).toBe("widget");
+    db.close();
+  });
+
+  test("再 open で既存メタが保持される", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue());
+    db.close();
+
+    const db2 = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    expect(getIssue(db2, 1)).toBeDefined();
+    db2.close();
+  });
+
+  test("token_hash 変更時に全テーブル purge", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 42 }));
+    expect(getIssue(db, 42)).toBeDefined();
+    db.close();
+
+    const db2 = openGhCacheDB(testDir, REPO, "b".repeat(32));
+    expect(getIssue(db2, 42) ?? undefined).toBeUndefined();
+    const meta = getSyncMeta(db2);
+    expect(meta!.token_hash).toBe("b".repeat(32));
+    db2.close();
+  });
+
+  test("repo 不一致時に全テーブル purge", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 99 }));
+    db.close();
+
+    const OTHER: RepoInfo = { ...REPO, repo: "other" };
+    const db2 = openGhCacheDB(testDir, OTHER, TOKEN_HASH);
+    expect(getIssue(db2, 99) ?? undefined).toBeUndefined();
+    const meta = getSyncMeta(db2);
+    expect(meta!.repo).toBe("other");
+    db2.close();
+  });
+});
+
+describe("upserts", () => {
+  test("upsertIssue は同 number で更新", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ title: "old" }));
+    upsertIssue(db, makeIssue({ title: "new" }));
+    const i = getIssue(db, 1);
+    expect(i?.title).toBe("new");
+    db.close();
+  });
+
+  test("upsertComment ON CONFLICT で更新", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 5 }));
+    upsertComment(db, {
+      id: 10,
+      issue_number: 5,
+      author_login: "bob",
+      body: "first",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      html_url: null,
+      raw_json: null,
+    });
+    upsertComment(db, {
+      id: 10,
+      issue_number: 5,
+      author_login: "bob",
+      body: "edited",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      html_url: null,
+      raw_json: null,
+    });
+    const stats = getCacheStats(db);
+    expect(stats.commentCount).toBe(1);
+    db.close();
+  });
+
+  test("linkIssueLabel → getIssueLabels", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 7 }));
+    upsertLabel(db, { id: 100, name: "bug", color: "red", description: null });
+    upsertLabel(db, { id: 101, name: "feature", color: "green", description: null });
+    linkIssueLabel(db, 7, 100);
+    linkIssueLabel(db, 7, 101);
+    const labels = getIssueLabels(db, 7);
+    expect(labels.map((l) => l.name).sort()).toEqual(["bug", "feature"]);
+    clearIssueLabels(db, 7);
+    expect(getIssueLabels(db, 7)).toHaveLength(0);
+    db.close();
+  });
+
+  test("linkIssueAssignee は assignees.id を PK に使う", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 11 }));
+    upsertAssignee(db, { id: 501, login: "charlie", avatar_url: null });
+    linkIssueAssignee(db, 11, 501);
+    const assignees = getIssueAssignees(db, 11);
+    expect(assignees[0]?.login).toBe("charlie");
+    clearIssueAssignees(db, 11);
+    expect(getIssueAssignees(db, 11)).toHaveLength(0);
+    db.close();
+  });
+});
+
+describe("setSyncMeta / getSyncMeta", () => {
+  test("patch で部分更新", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    setSyncMeta(db, { viewer_login: "alice", last_full_sync: "2026-04-01T00:00:00Z" });
+    const meta = getSyncMeta(db)!;
+    expect(meta.viewer_login).toBe("alice");
+    expect(meta.last_full_sync).toBe("2026-04-01T00:00:00Z");
+    db.close();
+  });
+
+  test("undefined は無視", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    setSyncMeta(db, { viewer_login: "keep" });
+    setSyncMeta(db, { viewer_login: undefined, last_full_sync: "2026-04-02T00:00:00Z" });
+    const meta = getSyncMeta(db)!;
+    expect(meta.viewer_login).toBe("keep");
+    expect(meta.last_full_sync).toBe("2026-04-02T00:00:00Z");
+    db.close();
+  });
+});
+
+describe("listIssues", () => {
+  test("type / state フィルタ", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 1, type: "issue", state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, type: "issue", state: "closed" }));
+    upsertIssue(db, makeIssue({ number: 3, type: "pr", state: "open" }));
+    upsertIssue(
+      db,
+      makeIssue({
+        number: 4,
+        type: "pr",
+        state: "closed",
+        merged_at: "2026-02-01T00:00:00Z",
+      }),
+    );
+
+    expect(listIssues(db, { type: "issue" }).map((i) => i.number).sort()).toEqual([
+      1, 2,
+    ]);
+    expect(listIssues(db, { type: "pr" }).map((i) => i.number).sort()).toEqual([3, 4]);
+    expect(
+      listIssues(db, { type: "pr", state: "merged" }).map((i) => i.number),
+    ).toEqual([4]);
+    expect(listIssues(db, { state: "open" }).map((i) => i.number).sort()).toEqual([
+      1, 3,
+    ]);
+    db.close();
+  });
+
+  test("assignee / label / author フィルタ", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 1, author_login: "alice" }));
+    upsertIssue(db, makeIssue({ number: 2, author_login: "bob" }));
+    upsertAssignee(db, { id: 11, login: "alice", avatar_url: null });
+    linkIssueAssignee(db, 1, 11);
+    upsertLabel(db, { id: 50, name: "bug", color: "red", description: null });
+    linkIssueLabel(db, 2, 50);
+
+    expect(listIssues(db, { authorLogin: "bob" }).map((i) => i.number)).toEqual([2]);
+    expect(
+      listIssues(db, { assigneeLogin: "alice" }).map((i) => i.number),
+    ).toEqual([1]);
+    expect(listIssues(db, { labelName: "bug" }).map((i) => i.number)).toEqual([2]);
+    db.close();
+  });
+
+  test("更新日時降順", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 1, updated_at: "2026-01-01T00:00:00Z" }));
+    upsertIssue(db, makeIssue({ number: 2, updated_at: "2026-02-01T00:00:00Z" }));
+    upsertIssue(db, makeIssue({ number: 3, updated_at: "2026-01-15T00:00:00Z" }));
+    const ids = listIssues(db).map((i) => i.number);
+    expect(ids).toEqual([2, 3, 1]);
+    db.close();
+  });
+});
+
+describe("getCacheStats", () => {
+  test("issue / PR / merged / comment をカウント", () => {
+    const db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+    upsertIssue(db, makeIssue({ number: 1, type: "issue", state: "open" }));
+    upsertIssue(db, makeIssue({ number: 2, type: "issue", state: "closed" }));
+    upsertIssue(db, makeIssue({ number: 3, type: "pr", state: "open" }));
+    upsertIssue(
+      db,
+      makeIssue({
+        number: 4,
+        type: "pr",
+        state: "closed",
+        merged_at: "2026-02-01T00:00:00Z",
+      }),
+    );
+    upsertComment(db, {
+      id: 10,
+      issue_number: 1,
+      author_login: "alice",
+      body: "hi",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      html_url: null,
+      raw_json: null,
+    });
+    const s = getCacheStats(db);
+    expect(s.issueCount).toBe(2);
+    expect(s.issueOpenCount).toBe(1);
+    expect(s.issueClosedCount).toBe(1);
+    expect(s.prCount).toBe(2);
+    expect(s.prOpenCount).toBe(1);
+    expect(s.prClosedCount).toBe(1);
+    expect(s.prMergedCount).toBe(1);
+    expect(s.commentCount).toBe(1);
+    db.close();
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-store.ts
+++ b/skills/cmux-team/manager/gh-cache-store.ts
@@ -1,0 +1,687 @@
+/**
+ * gh-cache store: .team/gh-cache.db の初期化・CRUD アクセサ。
+ *
+ * - bun:sqlite を使用、WAL モード、prepared statement のみ
+ * - (host, owner, repo) / token_hash 不一致時は全テーブル purge
+ * - マイグレーションは PRAGMA table_info ベース（trace-store.ts に倣う）
+ */
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "fs";
+import { join } from "path";
+import { log } from "./logger";
+import type {
+  AssigneeRow,
+  CommentRow,
+  IssueRow,
+  LabelRow,
+  MilestoneRow,
+  RepoInfo,
+  ReviewCommentRow,
+  ReviewRow,
+  SyncMeta,
+} from "./gh-cache-types";
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS issues (
+  number         INTEGER PRIMARY KEY,
+  type           TEXT    NOT NULL CHECK (type IN ('issue','pr')),
+  state          TEXT    NOT NULL,
+  title          TEXT    NOT NULL,
+  body           TEXT,
+  author_login   TEXT,
+  author_id      INTEGER,
+  created_at     TEXT    NOT NULL,
+  updated_at     TEXT    NOT NULL,
+  closed_at      TEXT,
+  merged_at      TEXT,
+  html_url       TEXT    NOT NULL,
+  comments_count INTEGER NOT NULL DEFAULT 0,
+  milestone_id   INTEGER,
+  draft          INTEGER,
+  etag           TEXT,
+  fetched_at     TEXT    NOT NULL,
+  raw_json       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_issues_updated  ON issues(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_issues_state    ON issues(state);
+CREATE INDEX IF NOT EXISTS idx_issues_type     ON issues(type);
+
+CREATE TABLE IF NOT EXISTS comments (
+  id            INTEGER PRIMARY KEY,
+  issue_number  INTEGER NOT NULL,
+  author_login  TEXT,
+  body          TEXT    NOT NULL,
+  created_at    TEXT    NOT NULL,
+  updated_at    TEXT    NOT NULL,
+  html_url      TEXT,
+  raw_json      TEXT,
+  FOREIGN KEY (issue_number) REFERENCES issues(number) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_comments_issue ON comments(issue_number);
+
+CREATE TABLE IF NOT EXISTS reviews (
+  id            INTEGER PRIMARY KEY,
+  pr_number     INTEGER NOT NULL,
+  author_login  TEXT,
+  state         TEXT    NOT NULL,
+  body          TEXT,
+  submitted_at  TEXT,
+  raw_json      TEXT,
+  FOREIGN KEY (pr_number) REFERENCES issues(number) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_reviews_pr ON reviews(pr_number);
+
+CREATE TABLE IF NOT EXISTS review_comments (
+  id            INTEGER PRIMARY KEY,
+  pr_number     INTEGER NOT NULL,
+  review_id     INTEGER,
+  author_login  TEXT,
+  body          TEXT    NOT NULL,
+  path          TEXT,
+  line          INTEGER,
+  original_line INTEGER,
+  commit_id     TEXT,
+  created_at    TEXT    NOT NULL,
+  updated_at    TEXT    NOT NULL,
+  raw_json      TEXT,
+  FOREIGN KEY (pr_number) REFERENCES issues(number) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_review_comments_pr ON review_comments(pr_number);
+
+CREATE TABLE IF NOT EXISTS labels (
+  id          INTEGER PRIMARY KEY,
+  name        TEXT    NOT NULL,
+  color       TEXT,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS issue_labels (
+  issue_number INTEGER NOT NULL,
+  label_id     INTEGER NOT NULL,
+  PRIMARY KEY (issue_number, label_id),
+  FOREIGN KEY (issue_number) REFERENCES issues(number) ON DELETE CASCADE,
+  FOREIGN KEY (label_id)     REFERENCES labels(id)     ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_issue_labels_issue ON issue_labels(issue_number);
+
+CREATE TABLE IF NOT EXISTS assignees (
+  id           INTEGER PRIMARY KEY,
+  login        TEXT    NOT NULL,
+  avatar_url   TEXT,
+  UNIQUE(login)
+);
+CREATE INDEX IF NOT EXISTS idx_assignees_login ON assignees(login);
+
+CREATE TABLE IF NOT EXISTS issue_assignees (
+  issue_number INTEGER NOT NULL,
+  user_id      INTEGER NOT NULL,
+  PRIMARY KEY (issue_number, user_id),
+  FOREIGN KEY (issue_number) REFERENCES issues(number)   ON DELETE CASCADE,
+  FOREIGN KEY (user_id)      REFERENCES assignees(id)    ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_issue_assignees_user ON issue_assignees(user_id);
+
+CREATE TABLE IF NOT EXISTS reactions (
+  id            INTEGER PRIMARY KEY,
+  target_type   TEXT    NOT NULL CHECK (target_type IN ('issue','comment','review_comment')),
+  target_id     INTEGER NOT NULL,
+  content       TEXT    NOT NULL,
+  user_login    TEXT,
+  created_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_reactions_target ON reactions(target_type, target_id);
+
+CREATE TABLE IF NOT EXISTS milestones (
+  id          INTEGER PRIMARY KEY,
+  number      INTEGER NOT NULL,
+  title       TEXT    NOT NULL,
+  state       TEXT,
+  due_on      TEXT,
+  raw_json    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sync_meta (
+  key                   TEXT    PRIMARY KEY,
+  token_hash            TEXT    NOT NULL,
+  host                  TEXT    NOT NULL,
+  owner                 TEXT    NOT NULL,
+  repo                  TEXT    NOT NULL,
+  viewer_login          TEXT,
+  etag_issues_list      TEXT,
+  last_full_sync        TEXT,
+  last_incremental_sync TEXT,
+  rate_limit_remaining  INTEGER,
+  rate_limit_reset      TEXT,
+  last_error            TEXT
+);
+`;
+
+/** DB を開き、スキーマ適用・WAL 有効化・purge 判定まで行う。 */
+export function openGhCacheDB(
+  projectRoot: string,
+  repoInfo: RepoInfo,
+  currentTokenHash: string,
+): Database {
+  const dir = join(projectRoot, ".team");
+  mkdirSync(dir, { recursive: true });
+  const db = new Database(join(dir, "gh-cache.db"));
+
+  db.exec("PRAGMA journal_mode=WAL;");
+  db.exec("PRAGMA foreign_keys=ON;");
+
+  db.exec(SCHEMA);
+  ensureSyncMetaColumns(db);
+  ensureAssigneesColumns(db);
+
+  const existing = db
+    .prepare("SELECT token_hash, host, owner, repo FROM sync_meta WHERE key=?")
+    .get("global") as
+    | { token_hash: string; host: string; owner: string; repo: string }
+    | undefined;
+
+  if (existing) {
+    const tokenMismatch = existing.token_hash !== currentTokenHash;
+    const repoMismatch =
+      existing.host !== repoInfo.host ||
+      existing.owner !== repoInfo.owner ||
+      existing.repo !== repoInfo.repo;
+
+    if (tokenMismatch || repoMismatch) {
+      const reason = tokenMismatch ? "token_rotated" : "repo_mismatch";
+      purgeAll(db, reason, repoInfo, currentTokenHash);
+      void log(
+        "gh_cache_purged",
+        `reason=${reason} old_hash=${existing.token_hash} new_hash=${currentTokenHash} ` +
+          `old_repo=${existing.host}/${existing.owner}/${existing.repo} ` +
+          `new_repo=${repoInfo.host}/${repoInfo.owner}/${repoInfo.repo}`,
+      );
+    }
+  } else {
+    // 初期行を INSERT
+    db.prepare(
+      `INSERT INTO sync_meta (key, token_hash, host, owner, repo)
+       VALUES ('global', ?, ?, ?, ?)`,
+    ).run(currentTokenHash, repoInfo.host, repoInfo.owner, repoInfo.repo);
+  }
+
+  return db;
+}
+
+function ensureSyncMetaColumns(db: Database): void {
+  const rows = db
+    .prepare("PRAGMA table_info(sync_meta)")
+    .all() as Array<{ name: string }>;
+  const existing = new Set(rows.map((r) => r.name));
+  const required: Array<{ name: string; type: string }> = [
+    { name: "viewer_login", type: "TEXT" },
+    { name: "etag_issues_list", type: "TEXT" },
+    { name: "last_full_sync", type: "TEXT" },
+    { name: "last_incremental_sync", type: "TEXT" },
+    { name: "rate_limit_remaining", type: "INTEGER" },
+    { name: "rate_limit_reset", type: "TEXT" },
+    { name: "last_error", type: "TEXT" },
+  ];
+  for (const { name, type } of required) {
+    if (!existing.has(name)) {
+      db.exec(`ALTER TABLE sync_meta ADD COLUMN ${name} ${type}`);
+    }
+  }
+}
+
+function ensureAssigneesColumns(db: Database): void {
+  const rows = db
+    .prepare("PRAGMA table_info(assignees)")
+    .all() as Array<{ name: string }>;
+  const existing = new Set(rows.map((r) => r.name));
+  if (!existing.has("avatar_url")) {
+    db.exec(`ALTER TABLE assignees ADD COLUMN avatar_url TEXT`);
+  }
+}
+
+/** 全テーブルをクリアし、sync_meta に新 key を INSERT する。 */
+export function purgeAll(
+  db: Database,
+  reason: string,
+  repoInfo: RepoInfo,
+  tokenHash: string,
+): void {
+  const tables = [
+    "reactions",
+    "issue_labels",
+    "issue_assignees",
+    "labels",
+    "assignees",
+    "review_comments",
+    "reviews",
+    "comments",
+    "issues",
+    "milestones",
+    "sync_meta",
+  ];
+  const tx = db.transaction(() => {
+    for (const t of tables) db.exec(`DELETE FROM ${t}`);
+    db.prepare(
+      `INSERT INTO sync_meta (key, token_hash, host, owner, repo)
+       VALUES ('global', ?, ?, ?, ?)`,
+    ).run(tokenHash, repoInfo.host, repoInfo.owner, repoInfo.repo);
+  });
+  tx();
+  void log("gh_cache_purged_tx", `reason=${reason}`);
+}
+
+// --- upsert ---
+
+export function upsertIssue(db: Database, row: IssueRow): void {
+  db.prepare(
+    `INSERT INTO issues (
+       number, type, state, title, body, author_login, author_id,
+       created_at, updated_at, closed_at, merged_at, html_url,
+       comments_count, milestone_id, draft, etag, fetched_at, raw_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(number) DO UPDATE SET
+       type=excluded.type,
+       state=excluded.state,
+       title=excluded.title,
+       body=excluded.body,
+       author_login=excluded.author_login,
+       author_id=excluded.author_id,
+       created_at=excluded.created_at,
+       updated_at=excluded.updated_at,
+       closed_at=excluded.closed_at,
+       merged_at=excluded.merged_at,
+       html_url=excluded.html_url,
+       comments_count=excluded.comments_count,
+       milestone_id=excluded.milestone_id,
+       draft=excluded.draft,
+       etag=excluded.etag,
+       fetched_at=excluded.fetched_at,
+       raw_json=excluded.raw_json`,
+  ).run(
+    row.number,
+    row.type,
+    row.state,
+    row.title,
+    row.body,
+    row.author_login,
+    row.author_id,
+    row.created_at,
+    row.updated_at,
+    row.closed_at,
+    row.merged_at,
+    row.html_url,
+    row.comments_count,
+    row.milestone_id,
+    row.draft,
+    row.etag,
+    row.fetched_at,
+    row.raw_json,
+  );
+}
+
+export function upsertComment(db: Database, row: CommentRow): void {
+  db.prepare(
+    `INSERT INTO comments (
+       id, issue_number, author_login, body, created_at, updated_at, html_url, raw_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       issue_number=excluded.issue_number,
+       author_login=excluded.author_login,
+       body=excluded.body,
+       created_at=excluded.created_at,
+       updated_at=excluded.updated_at,
+       html_url=excluded.html_url,
+       raw_json=excluded.raw_json`,
+  ).run(
+    row.id,
+    row.issue_number,
+    row.author_login,
+    row.body,
+    row.created_at,
+    row.updated_at,
+    row.html_url,
+    row.raw_json,
+  );
+}
+
+export function upsertReview(db: Database, row: ReviewRow): void {
+  db.prepare(
+    `INSERT INTO reviews (
+       id, pr_number, author_login, state, body, submitted_at, raw_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       pr_number=excluded.pr_number,
+       author_login=excluded.author_login,
+       state=excluded.state,
+       body=excluded.body,
+       submitted_at=excluded.submitted_at,
+       raw_json=excluded.raw_json`,
+  ).run(
+    row.id,
+    row.pr_number,
+    row.author_login,
+    row.state,
+    row.body,
+    row.submitted_at,
+    row.raw_json,
+  );
+}
+
+export function upsertReviewComment(db: Database, row: ReviewCommentRow): void {
+  db.prepare(
+    `INSERT INTO review_comments (
+       id, pr_number, review_id, author_login, body, path, line, original_line,
+       commit_id, created_at, updated_at, raw_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       pr_number=excluded.pr_number,
+       review_id=excluded.review_id,
+       author_login=excluded.author_login,
+       body=excluded.body,
+       path=excluded.path,
+       line=excluded.line,
+       original_line=excluded.original_line,
+       commit_id=excluded.commit_id,
+       created_at=excluded.created_at,
+       updated_at=excluded.updated_at,
+       raw_json=excluded.raw_json`,
+  ).run(
+    row.id,
+    row.pr_number,
+    row.review_id,
+    row.author_login,
+    row.body,
+    row.path,
+    row.line,
+    row.original_line,
+    row.commit_id,
+    row.created_at,
+    row.updated_at,
+    row.raw_json,
+  );
+}
+
+export function upsertLabel(db: Database, row: LabelRow): void {
+  db.prepare(
+    `INSERT INTO labels (id, name, color, description)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       name=excluded.name,
+       color=excluded.color,
+       description=excluded.description`,
+  ).run(row.id, row.name, row.color, row.description);
+}
+
+export function linkIssueLabel(
+  db: Database,
+  issueNumber: number,
+  labelId: number,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO issue_labels (issue_number, label_id) VALUES (?, ?)`,
+  ).run(issueNumber, labelId);
+}
+
+export function clearIssueLabels(db: Database, issueNumber: number): void {
+  db.prepare(`DELETE FROM issue_labels WHERE issue_number=?`).run(issueNumber);
+}
+
+export function upsertAssignee(db: Database, row: AssigneeRow): void {
+  db.prepare(
+    `INSERT INTO assignees (id, login, avatar_url)
+     VALUES (?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       login=excluded.login,
+       avatar_url=excluded.avatar_url`,
+  ).run(row.id, row.login, row.avatar_url);
+}
+
+export function linkIssueAssignee(
+  db: Database,
+  issueNumber: number,
+  userId: number,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO issue_assignees (issue_number, user_id) VALUES (?, ?)`,
+  ).run(issueNumber, userId);
+}
+
+export function clearIssueAssignees(db: Database, issueNumber: number): void {
+  db.prepare(`DELETE FROM issue_assignees WHERE issue_number=?`).run(issueNumber);
+}
+
+export function upsertMilestone(db: Database, row: MilestoneRow): void {
+  db.prepare(
+    `INSERT INTO milestones (id, number, title, state, due_on, raw_json)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       number=excluded.number,
+       title=excluded.title,
+       state=excluded.state,
+       due_on=excluded.due_on,
+       raw_json=excluded.raw_json`,
+  ).run(
+    row.id,
+    row.number,
+    row.title,
+    row.state,
+    row.due_on,
+    row.raw_json,
+  );
+}
+
+// --- sync_meta ---
+
+export function getSyncMeta(db: Database): SyncMeta | undefined {
+  return db
+    .prepare(
+      `SELECT key, token_hash, host, owner, repo, viewer_login,
+              etag_issues_list, last_full_sync, last_incremental_sync,
+              rate_limit_remaining, rate_limit_reset, last_error
+         FROM sync_meta WHERE key='global'`,
+    )
+    .get() as SyncMeta | undefined;
+}
+
+type SyncMetaPatch = Partial<Omit<SyncMeta, "key" | "host" | "owner" | "repo">>;
+
+export function setSyncMeta(db: Database, patch: SyncMetaPatch): void {
+  const entries = Object.entries(patch).filter(([, v]) => v !== undefined);
+  if (entries.length === 0) return;
+  const setClause = entries.map(([k]) => `${k}=?`).join(", ");
+  const values = entries.map(([, v]) => v);
+  db.prepare(`UPDATE sync_meta SET ${setClause} WHERE key='global'`).run(
+    ...(values as (string | number | null)[]),
+  );
+}
+
+// --- read helpers ---
+
+export interface IssueListFilter {
+  type?: "issue" | "pr" | "all";
+  state?: "open" | "closed" | "merged" | "all";
+  assigneeLogin?: string;
+  authorLogin?: string;
+  labelName?: string;
+  limit?: number;
+}
+
+export function listIssues(db: Database, f: IssueListFilter = {}): IssueRow[] {
+  const wheres: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (f.type && f.type !== "all") {
+    wheres.push("i.type=?");
+    params.push(f.type);
+  }
+  if (f.state && f.state !== "all") {
+    if (f.state === "merged") {
+      wheres.push("i.type='pr' AND i.merged_at IS NOT NULL");
+    } else {
+      wheres.push("i.state=?");
+      params.push(f.state);
+    }
+  }
+  if (f.authorLogin) {
+    wheres.push("i.author_login=?");
+    params.push(f.authorLogin);
+  }
+  if (f.assigneeLogin) {
+    wheres.push(
+      `i.number IN (SELECT ia.issue_number FROM issue_assignees ia
+                      JOIN assignees a ON a.id = ia.user_id
+                     WHERE a.login=?)`,
+    );
+    params.push(f.assigneeLogin);
+  }
+  if (f.labelName) {
+    wheres.push(
+      `i.number IN (SELECT il.issue_number FROM issue_labels il
+                      JOIN labels l ON l.id = il.label_id
+                     WHERE l.name=?)`,
+    );
+    params.push(f.labelName);
+  }
+
+  const where = wheres.length > 0 ? `WHERE ${wheres.join(" AND ")}` : "";
+  const limit = Math.max(1, Math.min(f.limit ?? 30, 1000));
+  const sql = `SELECT i.* FROM issues i ${where} ORDER BY i.updated_at DESC LIMIT ${limit}`;
+  return db.prepare(sql).all(...params) as IssueRow[];
+}
+
+export function getIssue(db: Database, number: number): IssueRow | undefined {
+  return db
+    .prepare(`SELECT * FROM issues WHERE number=?`)
+    .get(number) as IssueRow | undefined;
+}
+
+export function getIssueLabels(db: Database, issueNumber: number): LabelRow[] {
+  return db
+    .prepare(
+      `SELECT l.* FROM labels l
+         JOIN issue_labels il ON il.label_id = l.id
+        WHERE il.issue_number=?
+        ORDER BY l.name`,
+    )
+    .all(issueNumber) as LabelRow[];
+}
+
+export function getIssueAssignees(
+  db: Database,
+  issueNumber: number,
+): AssigneeRow[] {
+  return db
+    .prepare(
+      `SELECT a.* FROM assignees a
+         JOIN issue_assignees ia ON ia.user_id = a.id
+        WHERE ia.issue_number=?
+        ORDER BY a.login`,
+    )
+    .all(issueNumber) as AssigneeRow[];
+}
+
+export function getIssueComments(db: Database, issueNumber: number): CommentRow[] {
+  return db
+    .prepare(
+      `SELECT * FROM comments WHERE issue_number=? ORDER BY created_at ASC`,
+    )
+    .all(issueNumber) as CommentRow[];
+}
+
+export function getPrReviews(db: Database, prNumber: number): ReviewRow[] {
+  return db
+    .prepare(`SELECT * FROM reviews WHERE pr_number=? ORDER BY id ASC`)
+    .all(prNumber) as ReviewRow[];
+}
+
+export function getPrReviewComments(
+  db: Database,
+  prNumber: number,
+): ReviewCommentRow[] {
+  return db
+    .prepare(
+      `SELECT * FROM review_comments WHERE pr_number=? ORDER BY created_at ASC`,
+    )
+    .all(prNumber) as ReviewCommentRow[];
+}
+
+export function searchIssues(
+  db: Database,
+  query: string,
+  filter: IssueListFilter = {},
+): IssueRow[] {
+  // LIKE ベースの素朴検索（title / body にマッチ）。
+  // FTS5 は別の機会で導入可能（plan §8 将来作業）。
+  const qLike = `%${query.replace(/[%_]/g, (c) => `\\${c}`)}%`;
+  const wheres: string[] = ["(i.title LIKE ? ESCAPE '\\' OR i.body LIKE ? ESCAPE '\\')"];
+  const params: (string | number)[] = [qLike, qLike];
+
+  if (filter.type && filter.type !== "all") {
+    wheres.push("i.type=?");
+    params.push(filter.type);
+  }
+  if (filter.state && filter.state !== "all") {
+    if (filter.state === "merged") {
+      wheres.push("i.type='pr' AND i.merged_at IS NOT NULL");
+    } else {
+      wheres.push("i.state=?");
+      params.push(filter.state);
+    }
+  }
+
+  const limit = Math.max(1, Math.min(filter.limit ?? 30, 1000));
+  const sql = `SELECT i.* FROM issues i WHERE ${wheres.join(" AND ")} ORDER BY i.updated_at DESC LIMIT ${limit}`;
+  return db.prepare(sql).all(...params) as IssueRow[];
+}
+
+// --- stats（status コマンド用）---
+
+export interface CacheStats {
+  issueCount: number;
+  issueOpenCount: number;
+  issueClosedCount: number;
+  prCount: number;
+  prOpenCount: number;
+  prClosedCount: number;
+  prMergedCount: number;
+  commentCount: number;
+}
+
+export function getCacheStats(db: Database): CacheStats {
+  const issueCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='issue'`)
+    .get() as { c: number }).c;
+  const issueOpenCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='issue' AND state='open'`)
+    .get() as { c: number }).c;
+  const issueClosedCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='issue' AND state='closed'`)
+    .get() as { c: number }).c;
+  const prCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='pr'`)
+    .get() as { c: number }).c;
+  const prOpenCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='pr' AND state='open'`)
+    .get() as { c: number }).c;
+  const prClosedCount = (db
+    .prepare(`SELECT COUNT(*) AS c FROM issues WHERE type='pr' AND state='closed'`)
+    .get() as { c: number }).c;
+  const prMergedCount = (db
+    .prepare(
+      `SELECT COUNT(*) AS c FROM issues WHERE type='pr' AND merged_at IS NOT NULL`,
+    )
+    .get() as { c: number }).c;
+  const commentCount = (db.prepare(`SELECT COUNT(*) AS c FROM comments`).get() as {
+    c: number;
+  }).c;
+
+  return {
+    issueCount,
+    issueOpenCount,
+    issueClosedCount,
+    prCount,
+    prOpenCount,
+    prClosedCount,
+    prMergedCount,
+    commentCount,
+  };
+}

--- a/skills/cmux-team/manager/gh-cache-sync.test.ts
+++ b/skills/cmux-team/manager/gh-cache-sync.test.ts
@@ -1,0 +1,427 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { openGhCacheDB, getSyncMeta, getIssue } from "./gh-cache-store";
+import {
+  ghFetch,
+  parseNextLink,
+  issueToRow,
+  resolveViewerLogin,
+  syncFull,
+  syncIncremental,
+  RateLimitExhaustedError,
+  SyncHttpError,
+  type FetchLike,
+  type SyncDeps,
+} from "./gh-cache-sync";
+import type { AuthResolution, GhIssue, RepoInfo } from "./gh-cache-types";
+
+const REPO: RepoInfo = { host: "api.github.com", owner: "acme", repo: "widget" };
+const AUTH: AuthResolution = {
+  kind: "env",
+  token: "gh_test_token",
+  host: "api.github.com",
+  checked: ["GITHUB_TOKEN"],
+};
+const TOKEN_HASH = "a".repeat(32);
+
+let testDir: string;
+let db: ReturnType<typeof openGhCacheDB>;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "gh-cache-sync-test-"));
+  db = openGhCacheDB(testDir, REPO, TOKEN_HASH);
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function makeResponse(body: unknown, init: ResponseInit & { headers?: Record<string, string> } = {}): Response {
+  const headers = new Headers(init.headers ?? {});
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers,
+  });
+}
+
+function make304(init: { headers?: Record<string, string> } = {}): Response {
+  return new Response(null, { status: 304, headers: new Headers(init.headers ?? {}) });
+}
+
+function mkIssue(overrides: Partial<GhIssue> = {}): GhIssue {
+  return {
+    number: 1,
+    state: "open",
+    title: "sample",
+    body: "body",
+    user: { id: 100, login: "alice" },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    closed_at: null,
+    html_url: "https://github.com/acme/widget/issues/1",
+    comments: 0,
+    labels: [],
+    assignees: [],
+    ...overrides,
+  } as GhIssue;
+}
+
+type Handler = (url: string, init?: { method?: string; headers?: Record<string, string> }) => Response | Promise<Response>;
+
+function makeFetch(handler: Handler): { fetchFn: FetchLike; calls: Array<{ url: string; headers: Record<string, string> }> } {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const fetchFn: FetchLike = async (url, init) => {
+    calls.push({ url, headers: init?.headers ?? {} });
+    return await handler(url, init);
+  };
+  return { fetchFn, calls };
+}
+
+function rateHeaders(remaining: number, limit = 5000, resetUnix = Math.floor(Date.now() / 1000) + 3600): Record<string, string> {
+  return {
+    "x-ratelimit-remaining": String(remaining),
+    "x-ratelimit-limit": String(limit),
+    "x-ratelimit-reset": String(resetUnix),
+  };
+}
+
+describe("parseNextLink", () => {
+  test("next URL を抽出", () => {
+    const link = '<https://api.github.com/repositories/1/issues?page=2>; rel="next", <https://api.github.com/repositories/1/issues?page=5>; rel="last"';
+    expect(parseNextLink(link)).toBe("https://api.github.com/repositories/1/issues?page=2");
+  });
+
+  test("null header → null", () => {
+    expect(parseNextLink(null)).toBeNull();
+  });
+
+  test("next rel が無ければ null", () => {
+    const link = '<https://api.github.com/repositories/1/issues?page=5>; rel="last"';
+    expect(parseNextLink(link)).toBeNull();
+  });
+});
+
+describe("issueToRow", () => {
+  test("issue → type=issue", () => {
+    const row = issueToRow(mkIssue(), "2026-01-03T00:00:00Z");
+    expect(row.type).toBe("issue");
+    expect(row.state).toBe("open");
+    expect(row.merged_at).toBeNull();
+  });
+
+  test("PR (pull_request あり) → type=pr", () => {
+    const row = issueToRow(
+      mkIssue({ pull_request: { url: "https://api.github.com/..." } }) as GhIssue,
+      "2026-01-03T00:00:00Z",
+    );
+    expect(row.type).toBe("pr");
+  });
+
+  test("PR merged → state=merged", () => {
+    const row = issueToRow(
+      mkIssue({
+        state: "closed",
+        pull_request: { url: "x", merged_at: "2026-02-01T00:00:00Z" },
+      }) as GhIssue,
+      "2026-01-03T00:00:00Z",
+    );
+    expect(row.type).toBe("pr");
+    expect(row.state).toBe("merged");
+    expect(row.merged_at).toBe("2026-02-01T00:00:00Z");
+  });
+
+  test("draft boolean は 0/1 に正規化", () => {
+    const r1 = issueToRow(
+      mkIssue({ draft: true, pull_request: { url: "x" } }) as GhIssue,
+      "2026-01-03T00:00:00Z",
+    );
+    const r2 = issueToRow(
+      mkIssue({ draft: false, pull_request: { url: "x" } }) as GhIssue,
+      "2026-01-03T00:00:00Z",
+    );
+    expect(r1.draft).toBe(1);
+    expect(r2.draft).toBe(0);
+  });
+});
+
+describe("ghFetch", () => {
+  test("Authorization と User-Agent を付与", async () => {
+    const { fetchFn, calls } = makeFetch(() => makeResponse({}));
+    await ghFetch({ db, repoInfo: REPO, auth: AUTH, fetchFn }, "/foo");
+    expect(calls).toHaveLength(1);
+    const c = calls[0]!;
+    expect(c.url).toBe("https://api.github.com/foo");
+    expect(c.headers.Authorization).toBe("Bearer gh_test_token");
+    expect(c.headers["User-Agent"]).toBe("cmux-team-gh-cache");
+  });
+
+  test("etag 指定時に If-None-Match が付く", async () => {
+    const { fetchFn, calls } = makeFetch(() => makeResponse({}));
+    await ghFetch({ db, repoInfo: REPO, auth: AUTH, fetchFn }, "/foo", { etag: 'W/"abc"' });
+    expect(calls[0]!.headers["If-None-Match"]).toBe('W/"abc"');
+  });
+
+  test("絶対 URL はそのまま使う", async () => {
+    const { fetchFn, calls } = makeFetch(() => makeResponse({}));
+    await ghFetch(
+      { db, repoInfo: REPO, auth: AUTH, fetchFn },
+      "https://api.github.com/repositories/1/issues?page=2",
+    );
+    expect(calls[0]!.url).toBe("https://api.github.com/repositories/1/issues?page=2");
+  });
+});
+
+describe("resolveViewerLogin", () => {
+  test("/user 成功で sync_meta に login が入る", async () => {
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      return makeResponse({}, { status: 404 });
+    });
+    const login = await resolveViewerLogin({ db, repoInfo: REPO, auth: AUTH, fetchFn });
+    expect(login).toBe("alice");
+    expect(getSyncMeta(db)!.viewer_login).toBe("alice");
+  });
+
+  test("/user 失敗 → null、sync_meta は更新されない", async () => {
+    const { fetchFn } = makeFetch(() => makeResponse({}, { status: 401 }));
+    const login = await resolveViewerLogin({ db, repoInfo: REPO, auth: AUTH, fetchFn });
+    expect(login).toBeNull();
+    expect(getSyncMeta(db)!.viewer_login).toBeNull();
+  });
+});
+
+describe("syncFull", () => {
+  test("/user → /rate_limit → issues 1 ページで完了", async () => {
+    const issueA = mkIssue({ number: 1 });
+    const issueB = mkIssue({ number: 2, pull_request: { url: "x" } });
+    const { fetchFn, calls } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: Math.floor(Date.now() / 1000) + 3600 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?") && !url.includes("/comments")) {
+        return makeResponse([issueA, issueB], { headers: rateHeaders(4999) });
+      }
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    const result = await syncFull(deps);
+    expect(result.mode).toBe("full");
+    expect(result.notModified).toBe(false);
+    expect(result.fetchedIssues).toBe(2);
+    expect(getIssue(db, 1)).toBeDefined();
+    expect(getIssue(db, 2)?.type).toBe("pr");
+    const meta = getSyncMeta(db)!;
+    expect(meta.last_full_sync).toBeDefined();
+    expect(meta.viewer_login).toBe("alice");
+    expect(calls.some((c) => c.url.includes("state=all"))).toBe(true);
+    expect(calls.some((c) => c.url.includes("sort=updated"))).toBe(true);
+  });
+
+  test("rate limit remaining < FULL_THRESHOLD で RateLimitExhaustedError", async () => {
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 500, limit: 5000, reset: Math.floor(Date.now() / 1000) + 3600 } },
+          { headers: rateHeaders(500) },
+        );
+      }
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    await expect(syncFull(deps)).rejects.toBeInstanceOf(RateLimitExhaustedError);
+  });
+
+  test("401 で SyncHttpError", async () => {
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      return makeResponse({ message: "Bad credentials" }, { status: 401 });
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    await expect(syncFull(deps)).rejects.toBeInstanceOf(SyncHttpError);
+  });
+
+  test("ETag が先頭ページから sync_meta に保存される", async () => {
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) {
+        return makeResponse([], { headers: { ...rateHeaders(4999), etag: 'W/"top"' } });
+      }
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    await syncFull(deps);
+    expect(getSyncMeta(db)!.etag_issues_list).toBe('W/"top"');
+  });
+});
+
+describe("syncIncremental", () => {
+  test("meta 未初期化なら throw", async () => {
+    // 新規 DB ではまだ last_full_sync が null だが sync_meta 行自体は存在する。
+    // viewer_login も未設定の新規状態で incremental を走らせる動作を確認。
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) return makeResponse([], { headers: rateHeaders(4999) });
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    const result = await syncIncremental(deps);
+    expect(result.mode).toBe("incremental");
+  });
+
+  test("ETag 304 なら notModified=true で early return", async () => {
+    const { fetchFn, calls } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) {
+        // 初回 full で etag 保存、次に incremental 呼び出し
+        return makeResponse([], { headers: { ...rateHeaders(4999), etag: 'W/"v1"' } });
+      }
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    await syncFull(deps);
+
+    // 差分実行で 304 を返す fetch を新しく差し替え
+    const { fetchFn: fetchFn2, calls: calls2 } = makeFetch((url, init) => {
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) {
+        expect(init?.headers?.["If-None-Match"]).toBe('W/"v1"');
+        return make304({ headers: rateHeaders(4998) });
+      }
+      return makeResponse([]);
+    });
+    const deps2: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn: fetchFn2 };
+    const r = await syncIncremental(deps2);
+    expect(r.notModified).toBe(true);
+    expect(r.fetchedIssues).toBe(0);
+    void calls;
+    void calls2;
+  });
+
+  test("since クエリが last_incremental_sync から付く", async () => {
+    // 先に full で last_incremental_sync を埋める
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) {
+        return makeResponse([], { headers: { ...rateHeaders(4999), etag: 'W/"v1"' } });
+      }
+      return makeResponse([]);
+    });
+    const fixedDate = new Date("2026-04-01T00:00:00.000Z");
+    await syncFull({ db, repoInfo: REPO, auth: AUTH, fetchFn, now: () => fixedDate });
+
+    const sawSinceBox: { value: string | null } = { value: null };
+    const { fetchFn: fetchFn2 } = makeFetch((url) => {
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues?")) {
+        const m = url.match(/since=([^&]+)/);
+        if (m && m[1]) sawSinceBox.value = decodeURIComponent(m[1]);
+        return makeResponse([], { headers: { ...rateHeaders(4998), etag: 'W/"v2"' } });
+      }
+      return makeResponse([]);
+    });
+    await syncIncremental({ db, repoInfo: REPO, auth: AUTH, fetchFn: fetchFn2 });
+    expect(sawSinceBox.value).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  test("rate limit remaining < INCREMENTAL_THRESHOLD で RateLimitExhaustedError", async () => {
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 10, limit: 5000, reset: Math.floor(Date.now() / 1000) + 3600 } },
+          { headers: rateHeaders(10) },
+        );
+      }
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      return makeResponse([]);
+    });
+    const deps: SyncDeps = { db, repoInfo: REPO, auth: AUTH, fetchFn };
+    await expect(syncIncremental(deps)).rejects.toBeInstanceOf(RateLimitExhaustedError);
+  });
+
+  test("更新された issue は DB に反映される", async () => {
+    // 最初に full で 1 件入れる
+    const issue1 = mkIssue({ number: 1, title: "v1", updated_at: "2026-01-01T00:00:00Z" });
+    const issue1v2 = mkIssue({ number: 1, title: "v2", updated_at: "2026-02-01T00:00:00Z" });
+    const { fetchFn } = makeFetch((url) => {
+      if (url.endsWith("/user")) return makeResponse({ id: 1, login: "alice" });
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues/1/comments")) return makeResponse([]);
+      if (url.includes("/issues?")) {
+        return makeResponse([issue1], { headers: { ...rateHeaders(4999), etag: 'W/"v1"' } });
+      }
+      return makeResponse([]);
+    });
+    await syncFull({ db, repoInfo: REPO, auth: AUTH, fetchFn });
+    expect(getIssue(db, 1)?.title).toBe("v1");
+
+    const { fetchFn: fetchFn2 } = makeFetch((url) => {
+      if (url.endsWith("/rate_limit")) {
+        return makeResponse(
+          { rate: { remaining: 5000, limit: 5000, reset: 0 } },
+          { headers: rateHeaders(5000) },
+        );
+      }
+      if (url.includes("/issues/1/comments")) return makeResponse([]);
+      if (url.includes("/issues?")) {
+        return makeResponse([issue1v2], { headers: { ...rateHeaders(4998), etag: 'W/"v2"' } });
+      }
+      return makeResponse([]);
+    });
+    await syncIncremental({ db, repoInfo: REPO, auth: AUTH, fetchFn: fetchFn2 });
+    expect(getIssue(db, 1)?.title).toBe("v2");
+  });
+});

--- a/skills/cmux-team/manager/gh-cache-sync.ts
+++ b/skills/cmux-team/manager/gh-cache-sync.ts
@@ -1,0 +1,589 @@
+/**
+ * gh-cache sync: GitHub REST fetch + DB 書き込み。
+ *
+ * - 初回 500 件 (`syncFull`): `/repos/{o}/{r}/issues?state=all&sort=updated` を 5 ページ
+ * - 差分 (`syncIncremental`): `since=<last>` + ETag (`If-None-Match`) で 304 許容
+ * - 各 issue/PR の comments / reviews / review_comments を追加取得
+ * - rate limit ヘッダーを都度読み取り、不足時は中断
+ *
+ * 外部依存: 標準 `fetch` のみ。
+ */
+import type { Database } from "bun:sqlite";
+import { log } from "./logger";
+import {
+  clearIssueAssignees,
+  clearIssueLabels,
+  getIssue,
+  getSyncMeta,
+  linkIssueAssignee,
+  linkIssueLabel,
+  setSyncMeta,
+  upsertAssignee,
+  upsertComment,
+  upsertIssue,
+  upsertLabel,
+  upsertMilestone,
+  upsertReview,
+  upsertReviewComment,
+} from "./gh-cache-store";
+import { apiBaseUrl } from "./gh-cache-repo";
+import {
+  GhCommentSchema,
+  GhIssueSchema,
+  GhReviewCommentSchema,
+  GhReviewSchema,
+  GhUserSchema,
+  type AuthResolution,
+  type GhIssue,
+  type IssueRow,
+  type RateLimit,
+  type RepoInfo,
+  type SyncResult,
+} from "./gh-cache-types";
+
+export const RATE_LIMIT_FULL_THRESHOLD = 1200;
+export const RATE_LIMIT_INCREMENTAL_THRESHOLD = 50;
+export const RATE_LIMIT_WARN_THRESHOLD = 100;
+export const DEFAULT_FULL_PAGES = 5;
+export const DEFAULT_PER_PAGE = 100;
+
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<Response>;
+
+export interface SyncDeps {
+  db: Database;
+  repoInfo: RepoInfo;
+  auth: AuthResolution;
+  /** テスト差し替えポイント */
+  fetchFn?: FetchLike;
+  /** テスト用: 現在時刻を固定 */
+  now?: () => Date;
+}
+
+/** 秒単位の Unix → ISO8601 */
+function unixToIso(sec: number): string {
+  return new Date(sec * 1000).toISOString();
+}
+
+function nowIso(deps: SyncDeps): string {
+  const d = deps.now ? deps.now() : new Date();
+  return d.toISOString();
+}
+
+function readRateLimit(headers: Headers): RateLimit {
+  const remainingStr = headers.get("x-ratelimit-remaining");
+  const limitStr = headers.get("x-ratelimit-limit");
+  const resetStr = headers.get("x-ratelimit-reset");
+  return {
+    remaining: remainingStr != null ? Number(remainingStr) : null,
+    limit: limitStr != null ? Number(limitStr) : null,
+    resetAt: resetStr != null ? unixToIso(Number(resetStr)) : null,
+  };
+}
+
+/** GitHub API 呼び出しラッパー。
+ *  - Authorization header を付与
+ *  - User-Agent を付与（GitHub REST の必須）
+ *  - ETag 付き GET (`If-None-Match`) をサポート
+ */
+export async function ghFetch(
+  deps: SyncDeps,
+  path: string,
+  opts: { etag?: string | null; method?: string } = {},
+): Promise<Response> {
+  const base = apiBaseUrl(deps.repoInfo.host);
+  const url = path.startsWith("http") ? path : `${base}${path}`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "cmux-team-gh-cache",
+  };
+  if (deps.auth.token) {
+    headers.Authorization = `Bearer ${deps.auth.token}`;
+  }
+  if (opts.etag) {
+    headers["If-None-Match"] = opts.etag;
+  }
+  const fetchFn = deps.fetchFn ?? (globalThis.fetch as FetchLike);
+  return await fetchFn(url, { method: opts.method ?? "GET", headers });
+}
+
+/** `Link: <...>; rel="next"` の next URL を抽出。 */
+export function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const parts = linkHeader.split(",");
+  for (const part of parts) {
+    const m = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
+/** GET /user で viewer_login を取得し sync_meta に保存。 */
+export async function resolveViewerLogin(deps: SyncDeps): Promise<string | null> {
+  const res = await ghFetch(deps, "/user");
+  if (!res.ok) {
+    void log(
+      "gh_viewer_resolved_failed",
+      `host=${deps.repoInfo.host} status=${res.status}`,
+    );
+    return null;
+  }
+  const body = await res.json();
+  const parsed = GhUserSchema.safeParse(body);
+  if (!parsed.success) {
+    void log("gh_viewer_resolved_failed", `host=${deps.repoInfo.host} reason=parse_failed`);
+    return null;
+  }
+  setSyncMeta(deps.db, { viewer_login: parsed.data.login });
+  void log("gh_viewer_resolved", `login=${parsed.data.login} host=${deps.repoInfo.host}`);
+  return parsed.data.login;
+}
+
+/** /rate_limit で残量を取得し sync_meta に記録。 */
+export async function fetchRateLimit(deps: SyncDeps): Promise<RateLimit> {
+  const res = await ghFetch(deps, "/rate_limit");
+  const rl = readRateLimit(res.headers);
+  try {
+    const body = (await res.json()) as {
+      rate?: { remaining?: number; limit?: number; reset?: number };
+    };
+    const core = body.rate;
+    if (core) {
+      rl.remaining = core.remaining ?? rl.remaining;
+      rl.limit = core.limit ?? rl.limit;
+      rl.resetAt = core.reset ? unixToIso(core.reset) : rl.resetAt;
+    }
+  } catch {
+    // ignore body parse errors; header 値を返す
+  }
+  setSyncMeta(deps.db, {
+    rate_limit_remaining: rl.remaining,
+    rate_limit_reset: rl.resetAt,
+  });
+  return rl;
+}
+
+/** GhIssue から IssueRow（type/draft/merged_at 判別）を作る。 */
+export function issueToRow(issue: GhIssue, fetchedAt: string): IssueRow {
+  const isPr = issue.pull_request != null || issue.draft != null;
+  const mergedAt =
+    (issue as { merged_at?: string | null }).merged_at ??
+    issue.pull_request?.merged_at ??
+    null;
+  const state = isPr && mergedAt ? "merged" : issue.state;
+  return {
+    number: issue.number,
+    type: isPr ? "pr" : "issue",
+    state,
+    title: issue.title,
+    body: issue.body ?? null,
+    author_login: issue.user?.login ?? null,
+    author_id: issue.user?.id ?? null,
+    created_at: issue.created_at,
+    updated_at: issue.updated_at,
+    closed_at: issue.closed_at ?? null,
+    merged_at: mergedAt,
+    html_url: issue.html_url,
+    comments_count: issue.comments ?? 0,
+    milestone_id: issue.milestone?.id ?? null,
+    draft: issue.draft == null ? null : issue.draft ? 1 : 0,
+    etag: null,
+    fetched_at: fetchedAt,
+    raw_json: JSON.stringify(issue),
+  };
+}
+
+/** issue 1 件分を DB に反映（本体 + labels + assignees + milestone）。 */
+function persistIssue(db: Database, issue: GhIssue, fetchedAt: string): void {
+  const row = issueToRow(issue, fetchedAt);
+  upsertIssue(db, row);
+
+  clearIssueLabels(db, row.number);
+  for (const label of issue.labels ?? []) {
+    upsertLabel(db, {
+      id: label.id,
+      name: label.name,
+      color: label.color ?? null,
+      description: label.description ?? null,
+    });
+    linkIssueLabel(db, row.number, label.id);
+  }
+
+  clearIssueAssignees(db, row.number);
+  for (const user of issue.assignees ?? []) {
+    upsertAssignee(db, {
+      id: user.id,
+      login: user.login,
+      avatar_url: user.avatar_url ?? null,
+    });
+    linkIssueAssignee(db, row.number, user.id);
+  }
+
+  if (issue.milestone) {
+    upsertMilestone(db, {
+      id: issue.milestone.id,
+      number: issue.milestone.number,
+      title: issue.milestone.title,
+      state: issue.milestone.state ?? null,
+      due_on: issue.milestone.due_on ?? null,
+      raw_json: JSON.stringify(issue.milestone),
+    });
+  }
+}
+
+/** comments / reviews / review_comments を個別 fetch して DB に反映。 */
+async function syncIssueAttachments(
+  deps: SyncDeps,
+  issue: GhIssue,
+  counters: {
+    fetchedComments: number;
+    fetchedReviews: number;
+    fetchedReviewComments: number;
+  },
+): Promise<{
+  fetchedComments: number;
+  fetchedReviews: number;
+  fetchedReviewComments: number;
+}> {
+  const { db, repoInfo } = deps;
+  const issueNumber = issue.number;
+  const isPr = issue.pull_request != null || issue.draft != null;
+
+  if ((issue.comments ?? 0) > 0) {
+    const res = await ghFetch(
+      deps,
+      `/repos/${repoInfo.owner}/${repoInfo.repo}/issues/${issueNumber}/comments?per_page=100`,
+    );
+    if (res.ok) {
+      const body = await res.json();
+      if (Array.isArray(body)) {
+        for (const raw of body) {
+          const parsed = GhCommentSchema.safeParse(raw);
+          if (!parsed.success) continue;
+          upsertComment(db, {
+            id: parsed.data.id,
+            issue_number: issueNumber,
+            author_login: parsed.data.user?.login ?? null,
+            body: parsed.data.body,
+            created_at: parsed.data.created_at,
+            updated_at: parsed.data.updated_at,
+            html_url: parsed.data.html_url ?? null,
+            raw_json: JSON.stringify(parsed.data),
+          });
+          counters.fetchedComments += 1;
+        }
+      }
+    }
+  }
+
+  if (isPr) {
+    const reviewsRes = await ghFetch(
+      deps,
+      `/repos/${repoInfo.owner}/${repoInfo.repo}/pulls/${issueNumber}/reviews?per_page=100`,
+    );
+    if (reviewsRes.ok) {
+      const body = await reviewsRes.json();
+      if (Array.isArray(body)) {
+        for (const raw of body) {
+          const parsed = GhReviewSchema.safeParse(raw);
+          if (!parsed.success) continue;
+          upsertReview(db, {
+            id: parsed.data.id,
+            pr_number: issueNumber,
+            author_login: parsed.data.user?.login ?? null,
+            state: parsed.data.state,
+            body: parsed.data.body ?? null,
+            submitted_at: parsed.data.submitted_at ?? null,
+            raw_json: JSON.stringify(parsed.data),
+          });
+          counters.fetchedReviews += 1;
+        }
+      }
+    }
+
+    const rcRes = await ghFetch(
+      deps,
+      `/repos/${repoInfo.owner}/${repoInfo.repo}/pulls/${issueNumber}/comments?per_page=100`,
+    );
+    if (rcRes.ok) {
+      const body = await rcRes.json();
+      if (Array.isArray(body)) {
+        for (const raw of body) {
+          const parsed = GhReviewCommentSchema.safeParse(raw);
+          if (!parsed.success) continue;
+          upsertReviewComment(db, {
+            id: parsed.data.id,
+            pr_number: issueNumber,
+            review_id: parsed.data.pull_request_review_id ?? null,
+            author_login: parsed.data.user?.login ?? null,
+            body: parsed.data.body,
+            path: parsed.data.path ?? null,
+            line: parsed.data.line ?? null,
+            original_line: parsed.data.original_line ?? null,
+            commit_id: parsed.data.commit_id ?? null,
+            created_at: parsed.data.created_at,
+            updated_at: parsed.data.updated_at,
+            raw_json: JSON.stringify(parsed.data),
+          });
+          counters.fetchedReviewComments += 1;
+        }
+      }
+    }
+  }
+
+  return counters;
+}
+
+/** 初回 sync。 /issues?sort=updated を 5 ページ（最大 500 件）+ 付属データ。 */
+export async function syncFull(deps: SyncDeps): Promise<SyncResult> {
+  const started = performance.now();
+  const fetchedAt = nowIso(deps);
+  void log(
+    "gh_sync_started",
+    `mode=full host=${deps.repoInfo.host} owner=${deps.repoInfo.owner} repo=${deps.repoInfo.repo}`,
+  );
+
+  // viewer_login を先に解決（@me 解決用）
+  await resolveViewerLogin(deps);
+
+  // rate limit ガード
+  const rl0 = await fetchRateLimit(deps);
+  if (rl0.remaining != null && rl0.remaining < RATE_LIMIT_FULL_THRESHOLD) {
+    void log(
+      "gh_sync_rate_limited",
+      `remaining=${rl0.remaining} reset_at=${rl0.resetAt ?? "unknown"}`,
+    );
+    throw new RateLimitExhaustedError(rl0);
+  }
+
+  const counters = {
+    fetchedIssues: 0,
+    fetchedComments: 0,
+    fetchedReviews: 0,
+    fetchedReviewComments: 0,
+  };
+
+  let lastRate: RateLimit = rl0;
+  let url: string | null =
+    `/repos/${deps.repoInfo.owner}/${deps.repoInfo.repo}/issues?state=all&sort=updated&direction=desc&per_page=${DEFAULT_PER_PAGE}&page=1`;
+  let page = 0;
+  let topEtag: string | null = null;
+
+  while (url && page < DEFAULT_FULL_PAGES) {
+    page += 1;
+    const res = await ghFetch(deps, url);
+    lastRate = readRateLimit(res.headers);
+    if (page === 1) {
+      topEtag = res.headers.get("etag");
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      void log("gh_sync_failed", `stage=full_list http_status=${res.status}`);
+      throw new SyncHttpError(res.status, `fetch issues failed`);
+    }
+    if (!res.ok) {
+      void log("gh_sync_failed", `stage=full_list http_status=${res.status}`);
+      throw new SyncHttpError(res.status, `fetch issues failed`);
+    }
+
+    const body = await res.json();
+    if (!Array.isArray(body)) break;
+
+    for (const raw of body) {
+      const parsed = GhIssueSchema.safeParse(raw);
+      if (!parsed.success) continue;
+      persistIssue(deps.db, parsed.data, fetchedAt);
+      counters.fetchedIssues += 1;
+
+      // rate limit がゆるくなっていれば attachments も取る
+      if (
+        lastRate.remaining == null ||
+        lastRate.remaining > RATE_LIMIT_WARN_THRESHOLD
+      ) {
+        await syncIssueAttachments(deps, parsed.data, counters);
+      }
+    }
+
+    const next = parseNextLink(res.headers.get("link"));
+    url = next;
+  }
+
+  setSyncMeta(deps.db, {
+    etag_issues_list: topEtag,
+    last_full_sync: fetchedAt,
+    last_incremental_sync: fetchedAt,
+    rate_limit_remaining: lastRate.remaining ?? null,
+    rate_limit_reset: lastRate.resetAt ?? null,
+    last_error: null,
+  });
+
+  const durationMs = Math.round(performance.now() - started);
+  void log(
+    "gh_sync_completed",
+    `mode=full fetched_issues=${counters.fetchedIssues} fetched_comments=${counters.fetchedComments} duration_ms=${durationMs}`,
+  );
+
+  return {
+    mode: "full",
+    notModified: false,
+    fetchedIssues: counters.fetchedIssues,
+    fetchedComments: counters.fetchedComments,
+    fetchedReviews: counters.fetchedReviews,
+    fetchedReviewComments: counters.fetchedReviewComments,
+    durationMs,
+    rateLimitRemaining: lastRate.remaining ?? null,
+    rateLimitReset: lastRate.resetAt ?? null,
+  };
+}
+
+/** 差分 sync。ETag 304 なら書き込まず early return。 */
+export async function syncIncremental(deps: SyncDeps): Promise<SyncResult> {
+  const started = performance.now();
+  const fetchedAt = nowIso(deps);
+  void log(
+    "gh_sync_started",
+    `mode=incremental host=${deps.repoInfo.host} owner=${deps.repoInfo.owner} repo=${deps.repoInfo.repo}`,
+  );
+
+  const meta = getSyncMeta(deps.db);
+  if (!meta) {
+    throw new Error("gh-cache.db not initialized; run syncFull first");
+  }
+
+  // viewer_login が未解決なら取得
+  if (!meta.viewer_login) {
+    await resolveViewerLogin(deps);
+  }
+
+  // rate limit ガード
+  const rl0 = await fetchRateLimit(deps);
+  if (rl0.remaining != null && rl0.remaining < RATE_LIMIT_INCREMENTAL_THRESHOLD) {
+    void log(
+      "gh_sync_rate_limited",
+      `remaining=${rl0.remaining} reset_at=${rl0.resetAt ?? "unknown"}`,
+    );
+    throw new RateLimitExhaustedError(rl0);
+  }
+
+  const counters = {
+    fetchedIssues: 0,
+    fetchedComments: 0,
+    fetchedReviews: 0,
+    fetchedReviewComments: 0,
+  };
+
+  const since = meta.last_incremental_sync ?? meta.last_full_sync;
+  const sinceQuery = since ? `&since=${encodeURIComponent(since)}` : "";
+  let url: string | null =
+    `/repos/${deps.repoInfo.owner}/${deps.repoInfo.repo}/issues?state=all&sort=updated&direction=desc&per_page=${DEFAULT_PER_PAGE}${sinceQuery}`;
+
+  let lastRate: RateLimit = rl0;
+  let notModified = false;
+  let topEtag: string | null = meta.etag_issues_list ?? null;
+  let firstPage = true;
+
+  while (url) {
+    const res = await ghFetch(deps, url, {
+      etag: firstPage ? meta.etag_issues_list : undefined,
+    });
+    lastRate = readRateLimit(res.headers);
+
+    if (firstPage && res.status === 304) {
+      notModified = true;
+      break;
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      void log("gh_sync_failed", `stage=incremental_list http_status=${res.status}`);
+      throw new SyncHttpError(res.status, "fetch issues failed");
+    }
+    if (!res.ok) {
+      void log("gh_sync_failed", `stage=incremental_list http_status=${res.status}`);
+      throw new SyncHttpError(res.status, "fetch issues failed");
+    }
+
+    if (firstPage) {
+      topEtag = res.headers.get("etag");
+    }
+    firstPage = false;
+
+    const body = await res.json();
+    if (!Array.isArray(body)) break;
+
+    for (const raw of body) {
+      const parsed = GhIssueSchema.safeParse(raw);
+      if (!parsed.success) continue;
+
+      // updated_at が DB と同じなら skip（冪等）
+      const prev = getIssue(deps.db, parsed.data.number);
+      if (prev && prev.updated_at >= parsed.data.updated_at) {
+        // 念のため labels / assignees 再リンクだけ通す
+        persistIssue(deps.db, parsed.data, fetchedAt);
+        counters.fetchedIssues += 1;
+        continue;
+      }
+      persistIssue(deps.db, parsed.data, fetchedAt);
+      counters.fetchedIssues += 1;
+
+      if (
+        lastRate.remaining == null ||
+        lastRate.remaining > RATE_LIMIT_WARN_THRESHOLD
+      ) {
+        await syncIssueAttachments(deps, parsed.data, counters);
+      }
+    }
+
+    const next = parseNextLink(res.headers.get("link"));
+    url = next;
+  }
+
+  setSyncMeta(deps.db, {
+    etag_issues_list: topEtag,
+    last_incremental_sync: fetchedAt,
+    rate_limit_remaining: lastRate.remaining ?? null,
+    rate_limit_reset: lastRate.resetAt ?? null,
+    last_error: null,
+  });
+
+  const durationMs = Math.round(performance.now() - started);
+  void log(
+    "gh_sync_completed",
+    `mode=incremental not_modified=${notModified} fetched_issues=${counters.fetchedIssues} duration_ms=${durationMs}`,
+  );
+
+  return {
+    mode: "incremental",
+    notModified,
+    fetchedIssues: counters.fetchedIssues,
+    fetchedComments: counters.fetchedComments,
+    fetchedReviews: counters.fetchedReviews,
+    fetchedReviewComments: counters.fetchedReviewComments,
+    durationMs,
+    rateLimitRemaining: lastRate.remaining ?? null,
+    rateLimitReset: lastRate.resetAt ?? null,
+  };
+}
+
+// --- エラー ---
+
+export class SyncHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SyncHttpError";
+  }
+}
+
+export class RateLimitExhaustedError extends Error {
+  constructor(public readonly rateLimit: RateLimit) {
+    super(
+      `GitHub rate limit exhausted: remaining=${rateLimit.remaining} reset_at=${rateLimit.resetAt ?? "unknown"}`,
+    );
+    this.name = "RateLimitExhaustedError";
+  }
+}

--- a/skills/cmux-team/manager/gh-cache-types.ts
+++ b/skills/cmux-team/manager/gh-cache-types.ts
@@ -1,0 +1,241 @@
+/**
+ * gh-cache 型定義（zod スキーマ）
+ *
+ * GitHub REST API レスポンスの型チェック、DB レコード、CLI 引数を
+ * zod 経由で一元管理する。生 JSON のフィールド欠損を raw_json 以外で
+ * 扱う前に必ず parse を通す。
+ */
+import { z } from "zod";
+
+// --- GitHub API レスポンス（最小限、未知フィールドは passthrough）---
+
+export const GhUserSchema = z
+  .object({
+    id: z.number().int(),
+    login: z.string(),
+    avatar_url: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export const GhLabelSchema = z
+  .object({
+    id: z.number().int(),
+    name: z.string(),
+    color: z.string().optional().nullable(),
+    description: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export const GhMilestoneSchema = z
+  .object({
+    id: z.number().int(),
+    number: z.number().int(),
+    title: z.string(),
+    state: z.string().optional().nullable(),
+    due_on: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export const GhPullRequestRefSchema = z
+  .object({
+    url: z.string().optional(),
+    merged_at: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export const GhIssueSchema = z
+  .object({
+    number: z.number().int(),
+    state: z.string(),
+    title: z.string(),
+    body: z.string().optional().nullable(),
+    user: GhUserSchema.optional().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    closed_at: z.string().optional().nullable(),
+    html_url: z.string(),
+    comments: z.number().int().optional().default(0),
+    labels: z.array(GhLabelSchema).optional().default([]),
+    assignees: z.array(GhUserSchema).optional().default([]),
+    milestone: GhMilestoneSchema.optional().nullable(),
+    pull_request: GhPullRequestRefSchema.optional().nullable(),
+    draft: z.boolean().optional().nullable(),
+    // PR 本体 (GET /pulls/{n}) では merged_at が直接 top level
+    merged_at: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export type GhIssue = z.infer<typeof GhIssueSchema>;
+
+export const GhCommentSchema = z
+  .object({
+    id: z.number().int(),
+    body: z.string(),
+    user: GhUserSchema.optional().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    html_url: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export type GhComment = z.infer<typeof GhCommentSchema>;
+
+export const GhReviewSchema = z
+  .object({
+    id: z.number().int(),
+    user: GhUserSchema.optional().nullable(),
+    state: z.string(),
+    body: z.string().optional().nullable(),
+    submitted_at: z.string().optional().nullable(),
+  })
+  .passthrough();
+
+export type GhReview = z.infer<typeof GhReviewSchema>;
+
+export const GhReviewCommentSchema = z
+  .object({
+    id: z.number().int(),
+    pull_request_review_id: z.number().int().optional().nullable(),
+    user: GhUserSchema.optional().nullable(),
+    body: z.string(),
+    path: z.string().optional().nullable(),
+    line: z.number().int().optional().nullable(),
+    original_line: z.number().int().optional().nullable(),
+    commit_id: z.string().optional().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .passthrough();
+
+export type GhReviewComment = z.infer<typeof GhReviewCommentSchema>;
+
+// --- DB レコード（row 型）---
+
+export interface IssueRow {
+  number: number;
+  type: "issue" | "pr";
+  state: string;
+  title: string;
+  body: string | null;
+  author_login: string | null;
+  author_id: number | null;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  merged_at: string | null;
+  html_url: string;
+  comments_count: number;
+  milestone_id: number | null;
+  draft: number | null;
+  etag: string | null;
+  fetched_at: string;
+  raw_json: string | null;
+}
+
+export interface CommentRow {
+  id: number;
+  issue_number: number;
+  author_login: string | null;
+  body: string;
+  created_at: string;
+  updated_at: string;
+  html_url: string | null;
+  raw_json: string | null;
+}
+
+export interface ReviewRow {
+  id: number;
+  pr_number: number;
+  author_login: string | null;
+  state: string;
+  body: string | null;
+  submitted_at: string | null;
+  raw_json: string | null;
+}
+
+export interface ReviewCommentRow {
+  id: number;
+  pr_number: number;
+  review_id: number | null;
+  author_login: string | null;
+  body: string;
+  path: string | null;
+  line: number | null;
+  original_line: number | null;
+  commit_id: string | null;
+  created_at: string;
+  updated_at: string;
+  raw_json: string | null;
+}
+
+export interface LabelRow {
+  id: number;
+  name: string;
+  color: string | null;
+  description: string | null;
+}
+
+export interface AssigneeRow {
+  id: number;
+  login: string;
+  avatar_url: string | null;
+}
+
+export interface MilestoneRow {
+  id: number;
+  number: number;
+  title: string;
+  state: string | null;
+  due_on: string | null;
+  raw_json: string | null;
+}
+
+export interface SyncMeta {
+  key: "global";
+  token_hash: string;
+  host: string;
+  owner: string;
+  repo: string;
+  viewer_login: string | null;
+  etag_issues_list: string | null;
+  last_full_sync: string | null;
+  last_incremental_sync: string | null;
+  rate_limit_remaining: number | null;
+  rate_limit_reset: string | null;
+  last_error: string | null;
+}
+
+export interface SyncResult {
+  mode: "full" | "incremental";
+  notModified: boolean;
+  fetchedIssues: number;
+  fetchedComments: number;
+  fetchedReviews: number;
+  fetchedReviewComments: number;
+  durationMs: number;
+  rateLimitRemaining: number | null;
+  rateLimitReset: string | null;
+}
+
+export interface RepoInfo {
+  /** host: "api.github.com" or "ghe.example.com/api/v3" */
+  host: string;
+  owner: string;
+  repo: string;
+}
+
+export type AuthKind = "env" | "gh-cli" | "none";
+
+export interface AuthResolution {
+  kind: AuthKind;
+  token?: string;
+  host: string;
+  /** どの env 変数 / コマンドを試したかのリスト（未認証エラー表示用） */
+  checked: string[];
+}
+
+export interface RateLimit {
+  remaining: number | null;
+  limit: number | null;
+  resetAt: string | null;
+}

--- a/skills/cmux-team/manager/i18n.ts
+++ b/skills/cmux-team/manager/i18n.ts
@@ -703,6 +703,67 @@ Usage:
   cmux-team self-update                            manually queue an update task
 
 For details on each command: cmux-team <command> --help`,
+
+  // ── gh-cache (T272) ───────────────────────────────────────────────────────
+  gh_not_a_github_repo:
+    "Error: not a git repository, or origin is not GitHub / GHE.\n" +
+    "  cmux-team issue/pr requires a git repo with an origin on github.com or an enterprise instance.",
+  gh_auth_missing:
+    "Error: No GitHub token found for host {host}.\n" +
+    "  checked: {checked}\n" +
+    "Run one of:\n" +
+    "  gh auth login\n" +
+    "  export GITHUB_TOKEN=<your token>",
+  gh_rate_limit_exhausted:
+    "Error: GitHub rate limit exhausted. remaining={remaining} reset_at={reset_at}\n" +
+    "  Try `cmux-team issue list --stale-ok` to read from cache without syncing.",
+  gh_me_not_resolved:
+    "Error: @me cannot be resolved. Run `cmux-team gh sync` first so the cache knows your viewer login.",
+  gh_unknown_subcommand:
+    "Unknown subcommand: {sub}. Run `cmux-team gh --help`.",
+  gh_cache_not_initialized:
+    "Error: gh-cache.db is empty. Run `cmux-team gh sync --full` first.",
+  gh_stale_warning:
+    "Warning: last full sync was {days} days ago. Consider `cmux-team gh sync --full`.",
+  gh_issue_empty: "(no issues / PRs matched)",
+  gh_sync_success:
+    "Synced {mode}: issues={issues} comments={comments} reviews={reviews} duration={duration_ms}ms",
+  gh_sync_not_modified: "Not modified (304). last_sync={last_sync}",
+  gh_status_header: "GitHub cache status",
+  gh_status_last_full: "Last full sync:        {when}",
+  gh_status_last_incremental: "Last incremental sync: {when}",
+  gh_status_host: "host:                  {host}",
+  gh_status_repo: "repo:                  {owner}/{repo}",
+  gh_status_viewer: "viewer:                {viewer}",
+  gh_status_issue_counts:
+    "issue:                 {total} (open={open}, closed={closed})",
+  gh_status_pr_counts:
+    "PR:                    {total} (open={open}, closed={closed}, merged={merged})",
+  gh_status_comments: "comments:              {count}",
+  gh_status_rate: "rate limit:            {remaining} / {limit} (reset {reset})",
+  gh_status_token: "token hash:            {hash}",
+  gh_status_never_synced: "(never)",
+  gh_tui_tab_title: "Issues",
+  gh_tui_help_line:
+    "[R] sync  [Enter/O] open in viewer  [B] open in browser",
+  gh_tui_syncing: "Syncing...",
+  gh_tui_disabled_non_git:
+    "Issues tab disabled (not a git repo or origin not GitHub).",
+  gh_tui_disabled_no_auth:
+    "Issues tab needs authentication: run `gh auth login` or set GITHUB_TOKEN.",
+  gh_help: `cmux-team gh — GitHub issue/PR cache management
+
+Usage:
+  cmux-team gh sync [--full]          sync issues/PRs into .team/gh-cache.db
+  cmux-team gh status                 show cache status + rate limit
+
+Flags:
+  --full    fetch the last 500 issues/PRs (plus attachments) from scratch
+            (use on first run, after token rotation, or once a month)
+
+Without --full, sync uses If-None-Match + since= to fetch only changes.
+Non-git directories / non-GitHub origins exit 2. Missing auth exits 3.
+Rate-limit exhaustion exits 4.`,
 };
 
 const ja: typeof en = {
@@ -1383,6 +1444,67 @@ Usage:
   cmux-team self-update                            update タスクを手動起票
 
 各コマンドの詳細: cmux-team <command> --help`,
+
+  // ── gh-cache (T272) ───────────────────────────────────────────────────────
+  gh_not_a_github_repo:
+    "Error: git リポジトリ外、または origin が GitHub / GHE ではありません。\n" +
+    "  cmux-team issue/pr は origin が github.com または Enterprise インスタンスである必要があります。",
+  gh_auth_missing:
+    "Error: host {host} の GitHub トークンが見つかりません。\n" +
+    "  確認先: {checked}\n" +
+    "以下のいずれかを実行してください:\n" +
+    "  gh auth login\n" +
+    "  export GITHUB_TOKEN=<your token>",
+  gh_rate_limit_exhausted:
+    "Error: GitHub API のレート制限に到達しました。remaining={remaining} reset_at={reset_at}\n" +
+    "  `cmux-team issue list --stale-ok` でキャッシュから読み取れます（同期せずに表示）。",
+  gh_me_not_resolved:
+    "Error: @me を解決できません。先に `cmux-team gh sync` を実行して viewer login をキャッシュしてください。",
+  gh_unknown_subcommand:
+    "Unknown subcommand: {sub}. `cmux-team gh --help` を参照してください。",
+  gh_cache_not_initialized:
+    "Error: gh-cache.db が空です。先に `cmux-team gh sync --full` を実行してください。",
+  gh_stale_warning:
+    "Warning: 最後の full sync から {days} 日経過しています。`cmux-team gh sync --full` の実行を検討してください。",
+  gh_issue_empty: "(該当する issue / PR はありません)",
+  gh_sync_success:
+    "同期完了 {mode}: issues={issues} comments={comments} reviews={reviews} duration={duration_ms}ms",
+  gh_sync_not_modified: "変更なし (304)。last_sync={last_sync}",
+  gh_status_header: "GitHub cache status",
+  gh_status_last_full: "最終 full sync:        {when}",
+  gh_status_last_incremental: "最終 incremental sync: {when}",
+  gh_status_host: "host:                  {host}",
+  gh_status_repo: "repo:                  {owner}/{repo}",
+  gh_status_viewer: "viewer:                {viewer}",
+  gh_status_issue_counts:
+    "issue:                 {total} (open={open}, closed={closed})",
+  gh_status_pr_counts:
+    "PR:                    {total} (open={open}, closed={closed}, merged={merged})",
+  gh_status_comments: "comments:              {count}",
+  gh_status_rate: "rate limit:            {remaining} / {limit} (reset {reset})",
+  gh_status_token: "token hash:            {hash}",
+  gh_status_never_synced: "(未実行)",
+  gh_tui_tab_title: "Issues",
+  gh_tui_help_line:
+    "[R] 同期  [Enter/O] ビューアで開く  [B] ブラウザで開く",
+  gh_tui_syncing: "同期中...",
+  gh_tui_disabled_non_git:
+    "Issues タブは無効（git リポジトリでないか、origin が GitHub ではありません）。",
+  gh_tui_disabled_no_auth:
+    "Issues タブには認証が必要です。`gh auth login` を実行するか GITHUB_TOKEN を設定してください。",
+  gh_help: `cmux-team gh — GitHub issue/PR キャッシュ管理
+
+Usage:
+  cmux-team gh sync [--full]          issue/PR を .team/gh-cache.db に同期
+  cmux-team gh status                 キャッシュ状態とレート制限を表示
+
+Flags:
+  --full    直近 500 件の issue/PR（とその添付）を最初から取得する
+            （初回実行・トークンローテーション後・月次メンテ時に使用）
+
+--full なしの場合、If-None-Match + since= で差分だけを取得します。
+非 git ディレクトリ / 非 GitHub origin は exit 2、認証欠如は exit 3、
+レート制限到達は exit 4 で終了します。`,
 };
 
 const messages = { en, ja };

--- a/skills/cmux-team/manager/main.ts
+++ b/skills/cmux-team/manager/main.ts
@@ -65,6 +65,19 @@ import {
   AGENT_INSTRUCTIONS_MAX_BYTES,
 } from "./agent-instructions";
 import { expandProjectInstructions } from "./template";
+import { resolveOriginRepo } from "./gh-cache-repo";
+import { resolveGithubToken, tokenHash } from "./gh-cache-auth";
+import {
+  openGhCacheDB,
+  getSyncMeta,
+  getCacheStats,
+} from "./gh-cache-store";
+import {
+  syncFull,
+  syncIncremental,
+  RateLimitExhaustedError,
+  SyncHttpError,
+} from "./gh-cache-sync";
 
 // --- プロジェクトルート検出 ---
 function findProjectRoot(): string {
@@ -4174,6 +4187,172 @@ async function cmdSelfUpdate(): Promise<void> {
   }
 }
 
+// --- gh サブコマンド (T272) ---
+/**
+ * cmux-team gh — GitHub issue/PR キャッシュ管理
+ *   gh sync [--full]
+ *   gh status
+ *
+ * Exit codes:
+ *   0 success
+ *   1 generic
+ *   2 non-git / non-GitHub origin
+ *   3 auth missing
+ *   4 rate limit exhausted
+ */
+async function cmdGh(): Promise<void> {
+  if (hasHelpFlag()) showHelp(t("gh_help"));
+  const sub = args[1];
+  switch (sub) {
+    case "sync":
+      await cmdGhSync();
+      break;
+    case "status":
+      await cmdGhStatus();
+      break;
+    default:
+      console.error(t("gh_unknown_subcommand", { sub: sub ?? "" }));
+      process.exit(1);
+  }
+}
+
+/**
+ * `openGhCacheDB` に渡す前段: repo / token を解決して正規化した env を返す。
+ * 失敗時は各 exit code で process.exit する。
+ */
+async function resolveGhContext(): Promise<{
+  db: ReturnType<typeof openGhCacheDB>;
+  repoInfo: NonNullable<Awaited<ReturnType<typeof resolveOriginRepo>>>;
+  auth: Awaited<ReturnType<typeof resolveGithubToken>> & { token: string };
+}> {
+  const repoInfo = await resolveOriginRepo(PROJECT_ROOT);
+  if (!repoInfo) {
+    console.error(t("gh_not_a_github_repo"));
+    process.exit(2);
+  }
+  const auth = await resolveGithubToken(repoInfo.host);
+  if (auth.kind === "none" || !auth.token) {
+    console.error(
+      t("gh_auth_missing", {
+        host: repoInfo.host,
+        checked: auth.checked.join(", "),
+      }),
+    );
+    process.exit(3);
+  }
+  const db = openGhCacheDB(PROJECT_ROOT, repoInfo, tokenHash(auth.token));
+  return { db, repoInfo, auth: auth as typeof auth & { token: string } };
+}
+
+async function cmdGhSync(): Promise<void> {
+  const full = hasFlag("full");
+  const { db, repoInfo, auth } = await resolveGhContext();
+
+  try {
+    const result = full
+      ? await syncFull({ db, repoInfo, auth })
+      : await syncIncremental({ db, repoInfo, auth });
+
+    if (result.notModified) {
+      const meta = getSyncMeta(db);
+      console.log(
+        t("gh_sync_not_modified", {
+          last_sync: meta?.last_incremental_sync ?? meta?.last_full_sync ?? "-",
+        }),
+      );
+    } else {
+      console.log(
+        t("gh_sync_success", {
+          mode: result.mode,
+          issues: String(result.fetchedIssues),
+          comments: String(result.fetchedComments),
+          reviews: String(result.fetchedReviews),
+          duration_ms: String(result.durationMs),
+        }),
+      );
+    }
+    process.exit(0);
+  } catch (e) {
+    if (e instanceof RateLimitExhaustedError) {
+      console.error(
+        t("gh_rate_limit_exhausted", {
+          remaining: String(e.rateLimit.remaining ?? "?"),
+          reset_at: e.rateLimit.resetAt ?? "?",
+        }),
+      );
+      process.exit(4);
+    }
+    if (e instanceof SyncHttpError) {
+      console.error(`Error: GitHub API ${e.status}: ${e.message}`);
+      process.exit(1);
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
+}
+
+async function cmdGhStatus(): Promise<void> {
+  const repoInfo = await resolveOriginRepo(PROJECT_ROOT);
+  if (!repoInfo) {
+    console.error(t("gh_not_a_github_repo"));
+    process.exit(2);
+  }
+  const auth = await resolveGithubToken(repoInfo.host);
+  if (auth.kind === "none" || !auth.token) {
+    console.error(
+      t("gh_auth_missing", {
+        host: repoInfo.host,
+        checked: auth.checked.join(", "),
+      }),
+    );
+    process.exit(3);
+  }
+  const db = openGhCacheDB(PROJECT_ROOT, repoInfo, tokenHash(auth.token));
+  const meta = getSyncMeta(db);
+  const stats = getCacheStats(db);
+
+  console.log(t("gh_status_header"));
+  console.log(
+    t("gh_status_last_full", { when: meta?.last_full_sync ?? t("gh_status_never_synced") }),
+  );
+  console.log(
+    t("gh_status_last_incremental", {
+      when: meta?.last_incremental_sync ?? t("gh_status_never_synced"),
+    }),
+  );
+  console.log(t("gh_status_host", { host: repoInfo.host }));
+  console.log(
+    t("gh_status_repo", { owner: repoInfo.owner, repo: repoInfo.repo }),
+  );
+  console.log(t("gh_status_viewer", { viewer: meta?.viewer_login ?? "-" }));
+  console.log(
+    t("gh_status_issue_counts", {
+      total: String(stats.issueCount),
+      open: String(stats.issueOpenCount),
+      closed: String(stats.issueClosedCount),
+    }),
+  );
+  console.log(
+    t("gh_status_pr_counts", {
+      total: String(stats.prCount),
+      open: String(stats.prOpenCount),
+      closed: String(stats.prClosedCount),
+      merged: String(stats.prMergedCount),
+    }),
+  );
+  console.log(t("gh_status_comments", { count: String(stats.commentCount) }));
+  console.log(
+    t("gh_status_rate", {
+      remaining: meta?.rate_limit_remaining != null ? String(meta.rate_limit_remaining) : "?",
+      limit: "?",
+      reset: meta?.rate_limit_reset ?? "-",
+    }),
+  );
+  console.log(t("gh_status_token", { hash: tokenHash(auth.token) }));
+  process.exit(0);
+}
+
 // --- artifacts サブコマンド ---
 async function cmdArtifacts(): Promise<void> {
   if (hasHelpFlag()) showHelp(t("help_artifacts"));
@@ -4445,6 +4624,9 @@ switch (command) {
     break;
   case "list-agent-instructions":
     await cmdListAgentInstructions();
+    break;
+  case "gh":
+    await cmdGh();
     break;
   default:
     if (!command || hasHelpFlag()) {

--- a/skills/cmux-team/manager/main.ts
+++ b/skills/cmux-team/manager/main.ts
@@ -78,6 +78,13 @@ import {
   RateLimitExhaustedError,
   SyncHttpError,
 } from "./gh-cache-sync";
+import {
+  cmdIssueList,
+  cmdIssueShow,
+  cmdIssueSearch,
+  cmdPrList,
+  type CliDeps as CliDepsImport,
+} from "./gh-cache-cli";
 
 // --- プロジェクトルート検出 ---
 function findProjectRoot(): string {
@@ -4353,6 +4360,57 @@ async function cmdGhStatus(): Promise<void> {
   process.exit(0);
 }
 
+// --- issue / pr サブコマンド (T272 Phase 2) ---
+/**
+ * `cmux-team issue list|show|search [...]`
+ */
+async function cmdIssue(): Promise<void> {
+  if (hasHelpFlag()) showHelp(t("gh_help"));
+  const sub = args[1];
+  const ctx = await resolveGhContext();
+  const deps: CliDepsImport = { ...ctx, args };
+  switch (sub) {
+    case "list":
+      await cmdIssueList(deps);
+      process.exit(0);
+      break;
+    case "show":
+      await cmdIssueShow(deps, "issue");
+      process.exit(0);
+      break;
+    case "search":
+      await cmdIssueSearch(deps);
+      process.exit(0);
+      break;
+    default:
+      console.error(t("gh_unknown_subcommand", { sub: sub ?? "" }));
+      process.exit(1);
+  }
+}
+
+/**
+ * `cmux-team pr list|show [...]`
+ */
+async function cmdPr(): Promise<void> {
+  if (hasHelpFlag()) showHelp(t("gh_help"));
+  const sub = args[1];
+  const ctx = await resolveGhContext();
+  const deps: CliDepsImport = { ...ctx, args };
+  switch (sub) {
+    case "list":
+      await cmdPrList(deps);
+      process.exit(0);
+      break;
+    case "show":
+      await cmdIssueShow(deps, "pr");
+      process.exit(0);
+      break;
+    default:
+      console.error(t("gh_unknown_subcommand", { sub: sub ?? "" }));
+      process.exit(1);
+  }
+}
+
 // --- artifacts サブコマンド ---
 async function cmdArtifacts(): Promise<void> {
   if (hasHelpFlag()) showHelp(t("help_artifacts"));
@@ -4627,6 +4685,12 @@ switch (command) {
     break;
   case "gh":
     await cmdGh();
+    break;
+  case "issue":
+    await cmdIssue();
+    break;
+  case "pr":
+    await cmdPr();
     break;
   default:
     if (!command || hasHelpFlag()) {


### PR DESCRIPTION
## Summary

GitHub rate limit 枯渇対策として cmux-team daemon 管理の issue/PR ローカルキャッシュを整備する。対応 issue: #26

## Phase 範囲

| Phase | 内容 | commit |
|-------|------|--------|
| Phase 1 | `.team/gh-cache.db` 新設 (bun:sqlite + WAL)。REST ETag + `since` 差分同期、token / repo mismatch 自動 purge、`cmux-team gh sync|status` | `1a86ab5` |
| Phase 2 | `cmux-team issue list|show|search` / `pr list|show` (gh 互換 `--json` field selector) | `ce243e6` |
| Phase 3 | TUI Issues タブ (Rezi 辞書キーバインド、`$PAGER`/`openArtifactInViewer` プレビュー、`O` で `open`、`R` で 手動 sync) | `b51a437` |
| Phase 4 | Claude Code 誘導スキル `cmux-team-gh` 追加 | `4b57a54` |
| Phase 5 | GraphQL Projects V2 — 後送り（本 PR 対象外） |  |

## 設計判断（Design Review 反映済み）

v1 計画は Design Reviewer から 6 件の Must Fix を受けて v2 で全反映済み:

1. **TUI は Rezi 辞書キーバインド** — `ink` + `useInput` + `raw mode` ではなく `@rezi-ui/core` の dict 形式
2. **pager は既存 viewer 再利用** — `openArtifactInViewer` + `resolveMarkdownViewer`
3. **assignees PK 修正** — `id INTEGER PRIMARY KEY, login UNIQUE` + `issue_assignees` FK 修正（login は mutable）
4. **repo 不一致 purge** — `(host, owner, repo)` mismatch で全行 purge + `gh_cache_purged reason=repo_mismatch`
5. **WAL モード** — `openGhCacheDB` で `PRAGMA journal_mode=WAL`（TUI リーダを writer がブロックしない）
6. **schema_version 撤去** — `PRAGMA table_info` ベース（trace-store.ts 準拠、YAGNI）

## テスト結果

```
cd skills/cmux-team/manager && bun test
772 pass / 0 fail (1883 expect, 33 files, 36.49s)
```

## セキュリティ

- トークン平文ログなし（SHA-256 `token_hash` の 32 hex のみ）
- SQL prepared statement `?` プレースホルダ
- 非 git (`exit 2`) / 未認証 (`exit 3`) 時の graceful 終了 + guidance message
- fetch 非 2xx の安全処理

## 変更ファイル

**新規**（`skills/cmux-team/manager/gh-cache-*.ts` + テスト 7 本、`skills/cmux-team-gh/SKILL.md`）:

- `gh-cache-types.ts` / `gh-cache-repo.ts` / `gh-cache-auth.ts` / `gh-cache-store.ts` / `gh-cache-sync.ts` / `gh-cache-format.ts` / `gh-cache-cli.ts`
- `skills/cmux-team-gh/SKILL.md`

**編集**:

- `main.ts` (+246 行、`cmdIssue` / `cmdPr` / `cmdGh` dispatcher + `resolveGhContext`)
- `dashboard.tsx` (+291 行、Issues タブ、Rezi 辞書キーバインド、`openArtifactInViewer` 再利用)
- `i18n.ts` (+122 行)
- `.gitignore` (`.team/gh-cache.db{,-wal,-shm}`)

合計: 19 files changed, +4886 / -4（Phase 1-4）+ chore commit (+192 / -2)

## Minor Notes（PR レビューで対応可能）

- `gh-cache-cli.ts` 一部 CLI エラー文字列が英語ハードコード
- `cmux-team issue/pr --help` が汎用テキストを返す
- `--assignee @login` のドキュメント補強

## Test plan

- [ ] `cd skills/cmux-team/manager && bun test` が all pass
- [ ] 空の worktree で `cmux-team gh sync` が exit 2 (non-git) でガイダンス表示
- [ ] 認証なしで `cmux-team gh sync` が exit 3 でトークン解決チェーンを案内
- [ ] `cmux-team gh sync` 初回 500 件 + 2 回目差分 (ETag 304 + `since`) の動作確認
- [ ] `cmux-team issue list --json number,title,state,assignees` の gh 互換フィールド出力
- [ ] TUI Issues タブで `Enter` プレビュー / `O` で `open` / `R` で手動 sync
- [ ] token を別アカウントに差し替えて自動 purge 発火
- [ ] 別 repo の origin に切り替えて `(host, owner, repo)` mismatch purge 発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)