### PR TITLE
fix(manager): SESSION_ENDED race で assignTask 中にプロンプトが届かない問題を修正 (T302)

### DIFF
--- a/skills/cmux-team/manager/conductor.ts
+++ b/skills/cmux-team/manager/conductor.ts
@@ -515,6 +515,15 @@ export async function assignTask(
       await sleep(500);
       await sleep(2000);
 
+      // T302-race: /clear 送信後の待機中に SESSION_ENDED が先に処理され disconnected に
+      // なっていた場合、プロンプトを送っても届かない。例外として上位に伝播させ、
+      // assignTask catch ブロックが worktree を巻き戻す。タスクは "ready" のまま残り
+      // 次の idle Conductor に再割り当てされる。
+      // （TypeScript は上の代入から "assigning" に絞り込むが、await 点で他ルートが変異し得るため型アサーション）
+      if ((conductor.status as "assigning" | "disconnected") === "disconnected") {
+        throw new AssignTaskError("conductor", "session ended during assign (race: session_ended before prompt_sent)");
+      }
+
       // 新しいプロンプトを送信
       const promptText = `${promptFile} を読んで指示に従って作業してください。`;
       await _backend.send(sessionRef, promptText);

--- a/skills/cmux-team/manager/daemon.test.ts
+++ b/skills/cmux-team/manager/daemon.test.ts
@@ -2408,6 +2408,64 @@ describe("monitorConductors: assigning timeout (T232)", () => {
   });
 });
 
+// T302-race: /clear 送信成功後に SESSION_ENDED race で conductor が disconnected に → タスクは ready のまま
+describe("scanTasks: SESSION_ENDED race — assignTask 中に session が死んだ場合 (T302-race)", () => {
+  test("sleep 中に conductor.status が disconnected → タスクは ready のまま + conductor は disconnected", async () => {
+    const { execFile: execFileCb } = await import("child_process");
+    const { promisify } = await import("util");
+    const execFile = promisify(execFileCb);
+    await execFile("git", ["init", "-q", "-b", "main"], { cwd: testDir });
+    await execFile("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"], { cwd: testDir });
+
+    await createTask("302", "race-task");
+
+    const cmux = await import("./cmux");
+    const { spyOn } = await import("bun:test");
+
+    // conductor への参照を保持してスパイ内から変異させる
+    let conductorRef: ConductorState | undefined;
+    let sendCallCount = 0;
+    const sendSpy = spyOn(cmux, "send").mockImplementation(async (_surface, _text) => {
+      sendCallCount++;
+      if (sendCallCount === 1 && conductorRef) {
+        // 1 回目 (/clear) 送信完了直後に SESSION_ENDED race を模倣:
+        // daemon の handleMessage が SESSION_ENDED を処理して disconnected にする
+        conductorRef.status = "disconnected";
+      }
+    });
+    const sendKeySpy = spyOn(cmux, "sendKey").mockImplementation(async () => {});
+
+    try {
+      const state = await createDaemon(testDir);
+      state.mainBranch = "main"; // T302-race: assignTask の fail-stop を回避して cmux.send まで進める
+      conductorRef = {
+        surface: "surface:302r",
+        startedAt: new Date().toISOString(),
+        agents: [],
+        status: "idle",
+      };
+      state.conductors.set(conductorRef.surface, conductorRef);
+
+      await scanTasks(state);
+
+      // race guard が発火 → AssignTaskError(conductor) → scanTasks が disconnected に倒す
+      expect(conductorRef.status).toBe("disconnected");
+      expect(conductorRef.disconnectedAt).toBeDefined();
+
+      // send は /clear の 1 回だけ（race guard でプロンプト送信がブロックされた）
+      expect(sendCallCount).toBe(1);
+
+      // タスクは "ready" のまま（applyAssignCommit が呼ばれていない）
+      const { loadTaskState } = await import("./task");
+      const ts = await loadTaskState(testDir);
+      expect(ts["302"]?.status ?? "ready").toBe("ready");
+    } finally {
+      sendSpy.mockRestore();
+      sendKeySpy.mockRestore();
+    }
+  }, 30000);
+});
+
 // R4 (b): assignTask 中に /clear 送信失敗 → AssignTaskError("conductor") → disconnected
 describe("scanTasks: /clear 送信失敗時の conductor disconnected (T232 R4)", () => {
   test("cmux.send で例外 → AssignTaskError(conductor) → idleConductor.status === 'disconnected'", async () => {

--- a/skills/cmux-team/manager/daemon.ts
+++ b/skills/cmux-team/manager/daemon.ts
@@ -1505,6 +1505,11 @@ export async function handleMessage(state: DaemonState, message: QueueMessage): 
             prevStatus === "starting" ? "conductor_ready" : "conductor_recovered",
             formatSurface(message.surface, "C")
           );
+          // T302-race: disconnected → idle 復帰時に即 scanTasks を発火し、
+          // "ready" 状態で待機中のタスクをこの Conductor に再割り当てする。
+          if (prevStatus === "disconnected") {
+            requestWakeup(state);
+          }
         } else if (conductor.status === "assigning") {
           // T232: assignTask 実行中の /clear 完了 → SESSION_STARTED(source=clear) で running へ遷移
           conductor.status = "running";


### PR DESCRIPTION
## Summary

- **conductor.ts**: `/clear` 送信後の `sleep(2000)` 中に `SESSION_ENDED` race で `conductor.status` が `disconnected` になった場合、`AssignTaskError("conductor")` を投げてプロンプト送信をブロック。タスクは `"ready"` のまま残り次の idle Conductor に再割り当てされる
- **daemon.ts**: `disconnected → idle` 復帰時に `requestWakeup` を呼び出し、`"ready"` で待機中のタスクを即座に再割り当てできるようにする
- **daemon.test.ts**: `cmux.send` spy で `/clear` 送信直後に `conductor.status = "disconnected"` を注入し、race 条件を再現するテストを追加

## 根本原因

`assignTask` では `/clear` を送信した後 2.5 秒 sleep する。この間に `SESSION_ENDED` hook が処理されると `conductor.status = "disconnected"` になるが、sleep 完了後にタスクプロンプトが死んだターミナルに送られてしまう。新しいセッションが起動してもプロンプトは届かず、タスクが `assigned` のまま詰まる。

## Test plan

- [x] T302-race 専用テストがパスすること
- [x] 全 160 テストがパスすること (`bun test skills/cmux-team/manager/daemon.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)