### PR TITLE
docs(claude-md): state tracking 弱さへの構造的対応原則を明示化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,23 @@ Master（ユーザー対話）→ Manager（イベント駆動監視）→ Condu
 | **逸脱を防ぐより、逸脱しても安全な構造にする** | worktree 隔離 + 事後レビュー |
 | **構造的正しさを優先** | 状態遷移・責務分担・データフローが明示的に正しいこと。必要な抽象化（state machine、型で列挙された状態、専用ライブラリ等）は積極的に導入し、繰り返し発生するクラスのバグを構造で絶つ。局所的な if/else の継ぎ足しでモグラ叩きを続けない |
 
+### 設計原則の背景: state tracking 弱さへの構造的対応
+
+上記 5 原則は独立に並んでいるように見えて、**「transformer が state を内部で維持しなくて済む環境を設計する」** という 1 つの上位原理に収束する。
+
+現在の transformer は inherently sequential な state tracking を苦手とする（depth exhaustion）。長時間スコープ・複数セッションをまたぐ agent オーケストレーションでは、この弱さが必ず顕在化するため、環境側で構造的に補完する。
+
+新規スキル・コマンド・テンプレート・ツール追加時は以下を確認する：
+
+| 確認項目 | 既存実装の対応例 |
+|---|---|
+| **state を外部化しているか** — agent memory に頼らず FSM・artifact・DB に置く | `task-state.json` + Task FSM、`.team/artifacts/`、trace DB |
+| **silent state mutation を作っていないか** — 状態変更は必ず観測可能にする | CLI 強制（直接ファイル書き禁止 hook）、hook→daemon の決定論的経路 |
+| **observer が pull で観測できるか** — agent の自己申告を信用しない | Manager の pull 型監視、PID watcher、done マーカーファイル |
+| **statefulness を排除できないか** — 状態追跡を要求しない設計を優先 | worktree-per-task 隔離、絶対パス強制、stateless CLI |
+
+「agent が前回の state を覚えている前提」が必要になったら設計の sign of trouble。state を外部化するか、状態追跡を要求しない protocol に再設計する。
+
 ## 判断基準と優先順位
 
 ### タスクの優先順位（高→低）


### PR DESCRIPTION
## Summary

CLAUDE.md の「設計原則」テーブル直後に、5 原則を貫く上位原理を明文化するセクションを追加。

- **背景**: 現在の transformer は inherently sequential な state tracking を苦手とする (depth exhaustion, Mozer et al. "The Topological Trouble With Transformers" arXiv:2604.17121)。長時間スコープ・複数セッションをまたぐ agent オーケストレーションでこの弱さが顕在化するため、環境側で構造的に補完する必要がある。
- **これまで**: cmux-team の設計判断 (worktree 隔離、FSM 外部化、CLI 強制、pull 型監視等) は実装で痛い目に遭った収束的進化の結果、すべて state tracking 弱さへの対処に揃っていた。しかし暗黙原則として動いていただけで、新規追加時の判断基準として明文化されていなかった。
- **本 PR**: 既存原則の上位に位置する設計指針として明示化し、新規スキル・コマンド・ツール追加時のチェックリスト (state 外部化 / silent state mutation 回避 / pull 型 observer / statefulness 排除) を併記。

## 変更内容

`CLAUDE.md` に `### 設計原則の背景: state tracking 弱さへの構造的対応` セクションを追加 (+17 行)。既存原則の書き換えはしていない。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていないこと (Markdown table の整形、見出し階層)
- [ ] 既存の「設計原則」テーブルと「判断基準と優先順位」セクションの間に挿入されていること
- [ ] 既存実装例 (`task-state.json`, `.team/artifacts/`, hook→daemon 経路など) の参照先がリポジトリ実態と一致していること
- [ ] 新規スキル / コマンド追加時に、本セクションのチェックリストが実用的に機能するかレビューで確認

https://claude.ai/code/session_0182c7rvnJspw3D74brkYs4g

---
_Generated by [Claude Code](https://claude.ai/code/session_0182c7rvnJspw3D74brkYs4g)_