### PR TITLE
fix(manager): run_after_all drain で depends_on チェーン上の draft/aborted をブロッカー扱い (T387)

### DIFF
--- a/skills/cmux-team/manager/task.test.ts
+++ b/skills/cmux-team/manager/task.test.ts
@@ -5,6 +5,7 @@ import { createDummyProject, type DummyProject } from "./test-project";
 import {
   parseTaskMeta,
   filterExecutableTasks,
+  filterRunAfterAllTasks,
   sortByPriority,
   cascadeAbortToChildren,
   classifyResumeAction,
@@ -384,6 +385,81 @@ describe("filterExecutableTasks", () => {
       new Set(["20"]) // 実装はアサイン済み
     );
     expect(result.map((t) => t.id)).toEqual(["99999"]); // 新規のみ実行可能
+  });
+});
+
+describe("filterRunAfterAllTasks (T387)", () => {
+  const makeMeta = (
+    id: string,
+    status: string,
+    dependsOn: string[] = [],
+    runAfterAll: boolean = false,
+  ): TaskMeta => ({
+    id,
+    title: `task-${id}`,
+    status,
+    priority: "medium",
+    dependsOn,
+    runAfterAll,
+    exclusive: false,
+    filePath: `/path/${id}.md`,
+    fileName: `${id}.md`,
+    createdAt: "",
+  });
+
+  test("ready 依存元が draft なら drain 通過し run_after_all が返る (再現)", () => {
+    const t1 = makeMeta("1", "draft");
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const t3 = makeMeta("3", "ready", [], true);
+    const result = filterRunAfterAllTasks([t1, t2, t3], new Set(), new Set());
+    expect(result.map((t) => t.id)).toEqual(["3"]);
+  });
+
+  test("draft に依存する ready のみで run_after_all が無い場合は空配列", () => {
+    const t1 = makeMeta("1", "draft");
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const result = filterRunAfterAllTasks([t1, t2], new Set(), new Set());
+    expect(result).toEqual([]);
+  });
+
+  test("2 段間接の draft 依存もチェーン遡及で検出して drain 通過", () => {
+    const t1 = makeMeta("1", "draft");
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const t3 = makeMeta("3", "ready", ["2"]);
+    const t4 = makeMeta("4", "ready", [], true);
+    const result = filterRunAfterAllTasks([t1, t2, t3, t4], new Set(), new Set());
+    expect(result.map((t) => t.id)).toEqual(["4"]);
+  });
+
+  test("aborted 依存も draft と同様に drain 通過させる (cascade 漏れの保険)", () => {
+    const t1 = makeMeta("1", "aborted");
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const t3 = makeMeta("3", "ready", [], true);
+    const result = filterRunAfterAllTasks([t1, t2, t3], new Set(), new Set());
+    expect(result.map((t) => t.id)).toEqual(["3"]);
+  });
+
+  test("循環参照していても無限ループせず空配列を返す", () => {
+    const t1 = makeMeta("1", "ready", ["2"]);
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const t3 = makeMeta("3", "ready", [], true);
+    const result = filterRunAfterAllTasks([t1, t2, t3], new Set(), new Set());
+    expect(result).toEqual([]);
+  });
+
+  test("closed のみのチェーンならブロッカーなし、T2 は normalActive に残り drain ブロック (既存挙動)", () => {
+    const t1 = makeMeta("1", "closed");
+    const t2 = makeMeta("2", "ready", ["1"]);
+    const t3 = makeMeta("3", "ready", [], true);
+    const result = filterRunAfterAllTasks([t1, t2, t3], new Set(["1"]), new Set());
+    expect(result).toEqual([]);
+  });
+
+  test("依存先タスクが削除済み（byId に無い）なら無視して既存挙動を維持", () => {
+    const t2 = makeMeta("2", "ready", ["999"]);
+    const t3 = makeMeta("3", "ready", [], true);
+    const result = filterRunAfterAllTasks([t2, t3], new Set(), new Set());
+    expect(result).toEqual([]);
   });
 });
 

--- a/skills/cmux-team/manager/task.ts
+++ b/skills/cmux-team/manager/task.ts
@@ -486,11 +486,34 @@ export function filterRunAfterAllTasks(
     ).map(t => t.id)
   );
 
-  // 通常タスク（run_after_all でも、run_after_all に依存するタスクでもない）の ready + assigned 数
+  // すべてのタスクを id で引けるマップ（チェーン遡及で再利用）
+  const byId = new Map(tasks.map(t => [t.id, t]));
+
+  // ready/assigned タスクが「進む見込みのない依存」(draft/aborted) を持つかを BFS で再帰判定。
+  // 循環は visited で防ぐ。closed はそれ以上辿らない。byId に無い依存は無視する（既存挙動踏襲）。
+  const isBlockedByDeadDep = (task: TaskMeta): boolean => {
+    const visited = new Set<string>();
+    const queue: string[] = [...task.dependsOn];
+    while (queue.length > 0) {
+      const depId = queue.shift()!;
+      if (visited.has(depId)) continue;
+      visited.add(depId);
+      const dep = byId.get(depId);
+      if (!dep) continue;
+      if (dep.status === "draft" || dep.status === "aborted") return true;
+      if (dep.status === "closed") continue;
+      queue.push(...dep.dependsOn);
+    }
+    return false;
+  };
+
+  // 通常タスク（run_after_all でも、run_after_all に依存するタスクでもない）の ready + assigned 数。
+  // チェーンを遡って draft/aborted に到達する場合は drain ブロッカーから除外する（T387）。
   const normalActive = tasks.filter(t =>
     !t.runAfterAll &&
     !dependsOnRunAfterAll.has(t.id) &&
-    (t.status === "ready" || assignedIds.has(t.id))
+    (t.status === "ready" || assignedIds.has(t.id)) &&
+    !isBlockedByDeadDep(t)
   );
 
   if (normalActive.length > 0) return [];


### PR DESCRIPTION
## Summary
- `filterRunAfterAllTasks` の `normalActive` 判定が ready タスクの直接の status のみを見ていたため、依存元が `draft` で ready 化されない場合に `run_after_all` タスクが永久に drain ブロックされるデッドロックが発生していた。
- ready/assigned タスクの `dependsOn` チェーンを BFS で再帰的に遡り、チェーン上に `draft` または `aborted` のタスクが存在すれば「進む見込みがない」として `normalActive` から除外する。
- `aborted` 検出は cascade 漏れ・将来の呼び出し側変更に対する safety net。

## デッドロック例（修正前）
```
T1: draft       (ユーザーが ready 昇格してない、放置)
T2: ready, depends_on T1  ← normalActive に含まれて drain ブロック
T3: run_after_all, ready  ← 永久に走らない
```

## 実装

`skills/cmux-team/manager/task.ts` `filterRunAfterAllTasks`:
- `byId: Map<string, TaskMeta>` を構築
- `isBlockedByDeadDep(task)` ローカル関数で BFS 走査（`visited` で循環防止、`closed` 終端、削除済み依存は無視）
- `normalActive` の filter 条件に `&& !isBlockedByDeadDep(t)` を追加

後段の `return tasks.filter(...)`（run_after_all 自身の `dependsOn` 判定）は無修正。

## Test plan

- [x] 追加テスト 7 ケース（再現 / 直接 draft / 2 段間接 / aborted / 循環 / closed のみ / 削除済み依存）すべて pass
- [x] `task.test.ts` 単体: 107 pass / 0 fail
- [x] manager 全テストファイル個別実行（`bun test` 全体禁忌遵守）: 62 files green
- [x] `bunx tsc --noEmit`: exit 0、エラー 0 件
- [x] daemon.ts:2754-2768 呼び出し側 signature 不変、既存呼び出しに互換

## 関連

- 既存 `filterExecutableTasks` (task.ts:443) は通常タスク用で本修正の対象外（タスク本文「関連」セクション参照）。
- `filterRunAfterAllTasks` の drain 判定にのみクローズ。

Refs: T387