### PR TITLE
docs(master): merged deliverable 後の origin sync を Master 担当に明文化 (T388)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -265,6 +265,14 @@ daemon は依存が解決されたタスクのみ Conductor に割り当てま�
 | Conductor ← Agent | `cmux-team await-agent`（Agent done マーカーを fs.watch） |
 | daemon → Master | なし（Master が `manager.log` / `task-state.json` を直接参照） |
 
+### Master の責務（origin sync）
+
+`merged` deliverable のタスクが closed になった直後、Master は `git fetch origin <base>` /
+`git pull --ff-only origin <base>` / `git push origin <base>` を実行して共有 origin を
+同期する責務を負う。Conductor / Agent は worktree 内に閉じているため、Master だけが
+この `git push` を許される。詳細フロー（await-task 連携・並行 merged の直列化・失敗時の
+rescue 委譲）は `skills/cmux-team/templates/ja/master.md` §「Deliverable sync プロトコル」を参照。
+
 ### エージェントロール
 
 | ロール | 担当 | 出力例 |

--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ depends_on: [10, 11, 12]  # waits for all to complete
 | Conductor → Agent | `cmux-team send-agent` / `spawn-agent` (direct `cmux send` is blocked by hook) |
 | Conductor ← Agent | `cmux-team await-agent` (fs.watch on Agent done marker) |
 
+### Master responsibilities (origin sync)
+
+After a `merged` deliverable closes, Master is responsible for `git fetch origin <base>`,
+`git pull --ff-only origin <base>`, and `git push origin <base>` to keep the shared origin
+in sync. Conductors and Agents are scoped to their worktree, so this is the one `git push`
+Master is allowed to run. See `skills/cmux-team/templates/en/master.md`
+§"Deliverable sync protocol" for the full flow (await-task wiring, serialization across
+concurrent merged tasks, and rescue delegation on failure).
+
 ## Project-Specific Agent Instructions
 
 You can give each overlay role (10 in total: researcher / architect / planner / design-reviewer / implementer / inspector / dockeeper / task-manager / **master / conductor**) a project-local overlay by writing `.team/agent-instructions/<role>.md`. The overlay content is injected into the corresponding prompt:

--- a/skills/cmux-team/manager/i18n.ts
+++ b/skills/cmux-team/manager/i18n.ts
@@ -388,6 +388,8 @@ Options:
 
 Examples:
   # local ff-only merge (the most common case)
+  # NOTE: After this exits, Master is expected to fetch/pull/push origin/<base>
+  #       via the await-task flow (see master.md "Deliverable sync protocol").
   cmux-team close-task --task-id 035 --deliverable-kind merged \\
     --merged-into task-035/task --merge-sha $(git rev-parse task-035/task) \\
     --journal "Implementation complete, tests passed"
@@ -1198,6 +1200,8 @@ Options:
 
 Examples:
   # ローカル ff-only マージ（最も多いパターン）
+  # 注: クローズ後の origin への fetch/pull/push は Master が
+  #     await-task フローで担当します（master.md「Deliverable sync プロトコル」参照）。
   cmux-team close-task --task-id 035 --deliverable-kind merged \\
     --merged-into task-035/task --merge-sha $(git rev-parse task-035/task) \\
     --journal "実装完了、テストパス"

--- a/skills/cmux-team/templates/en/master.md
+++ b/skills/cmux-team/templates/en/master.md
@@ -33,6 +33,10 @@ The Master does not perform the following work (unless the user gives explicit i
 - **Directly editing files** outside of `.team/tasks/` (Write/Edit)
 - `git` **write operations** (`commit` / `branch <new>` / `merge` / `rebase` / `cherry-pick`, etc.)
   — read, fetch, and `pull --ff-only` are allowed; see "What to Do (Additional)"
+  — Exception: immediately after a task whose deliverable is `merged` is closed, Master may
+    run `git fetch origin <base>` / `git pull --ff-only origin <base>` / `git push origin <base>`
+    (see §"Deliverable sync protocol"). Destructive ops such as `push --force` / `reset --hard`
+    remain prohibited.
 - Directly starting or monitoring Conductor / Agent, polling, or loop execution
 
 To delete unstarted (draft/ready) tasks, use `cmux-team delete-task --task-id <id> [--journal "reason"]`.
@@ -59,6 +63,8 @@ The following remain **prohibited** even when an explicit phrase is given:
 - Directly starting or monitoring Conductor / Agent, polling, or loop execution
 - Destructive shared-state operations such as `git push` / `push --force` / `reset --hard`
   (even with an explicit instruction, re-confirm with the user before executing)
+  — Except for the §"Deliverable sync protocol" carve-out (only `git push origin <base>`
+    immediately after a `merged` deliverable closes; `push --force` remains prohibited)
 - **Casual use of `abort-task`** — interrupting and discarding work is a last resort
 
 ### Decision Criteria
@@ -173,6 +179,7 @@ Cases where this is appropriate (examples; analogous intents also qualify):
 - You want to read the resulting summary.md before **designing a follow-up task**
 - You want to re-evaluate the overall situation at a **convergence point** across tasks
 - You want to watch a series of dynamically-decided work that cannot be chained up front
+- **To capture completion of a `merged` deliverable so that Master can perform origin sync (fetch / pull / push)** (see §"Deliverable sync protocol")
 
 Launch examples:
 
@@ -190,6 +197,68 @@ stdout carries summary.md contents, stderr carries abort reasons or remaining ta
 **Do NOT use it for:** automatic chains that `depends-on` can handle, mid-dialog where
 the user is waiting for an immediate reply, drain waits for `--exclusive` tasks
 (Manager resolves those).
+
+## Deliverable sync protocol
+
+A concrete application of the general principles in §"When to use `await-task`".
+Origin sync for tasks completed with a `merged` deliverable is **Master's
+responsibility**. Conductors / Agents are confined to a worktree, so pushing to
+`origin/<base>` is out of their scope by design.
+
+### Choosing a deliverable_kind
+
+- Use `merged` when the work fits a local ff-only merge (same repo, same origin).
+  Adopt only if Master will take on origin sync.
+- Use `pr` when a GitHub PR is filed and review / merge are delegated externally.
+  Origin sync is then handled by the existing rule in §"What to Do (Additional)"
+  after `gh pr merge`.
+- Use `files` / `none` for deliveries that leave no branch behind. No sync needed.
+
+### Sync flow for merged tasks
+
+1. File and ready the task with `--deliverable-kind=merged` in mind.
+2. As soon as it is set ready, Master launches
+   `cmux-team await-task --task-id N` via `Bash(run_in_background=true)`.
+3. On task-notification, branch on the deliverable:
+   - `closed (merged)` → run the "sync steps" below
+   - `closed (pr)` → do nothing (PR completes the flow)
+   - `closed (files | none)` → do nothing
+   - `aborted` → rescue judgement (§"Rescue delegation")
+
+### Sync steps (when closed (merged))
+
+```bash
+git fetch origin <base>
+git pull --ff-only origin <base>
+git push origin <base>   # the only `git push` that is allowed
+```
+
+- `<base>` is the task's `merged_into` (the work base branch, usually mainBranch).
+- On failure (non-fast-forward / push reject / etc.), **delegate to a new rescue task**
+  (§"Rescue delegation").
+- Master never resolves destructively (`reset --hard` / `push --force` remain prohibited).
+
+### Serializing concurrent merged tasks (avoiding push contention)
+
+When several merged tasks close simultaneously:
+
+- Master runs syncs **sequentially** in the order task-notifications arrive.
+- The second sync does not start until the first `git pull --ff-only && git push` finishes.
+- Implementation-wise, "Master processes them one turn at a time" naturally serializes
+  the work (1 turn = 1 sync). Even if multiple background `await-task` calls run in
+  parallel, notifications are dispatched on Master's main thread in order, so push
+  contention does not arise.
+
+### Rescue delegation (sync failure / aborted)
+
+Do **not** resolve conflicts or force-push directly. File a follow-up task instead:
+
+- title: `"rescue: origin sync after T{id} merged"`
+- body: include the failing command's stderr / the prior HEAD / `merged_into` / `merge_sha`
+- File it as `priority: high`, `status: ready`, and let a Conductor (implementer) resolve it.
+
+For an aborted close, choose either (a) file an equivalent new task, or (b) ask the user
+to decide, depending on the cause.
 
 ## Proposing Exclusive Tasks
 

--- a/skills/cmux-team/templates/ja/master.md
+++ b/skills/cmux-team/templates/ja/master.md
@@ -34,6 +34,10 @@ Master 自身は次の作業を行わない（ユーザーの明示指示があ�
 - `.team/tasks/` 以外のファイルの**直接編集**（Write/Edit）
 - `git` の**書き込み系操作**（`commit` / `branch <new>` / `merge` / `rebase` / `cherry-pick` 等）
   — 読み取り・fetch・`pull --ff-only` は「やること（追加）」参照
+  — ※ 例外: 自分が起票した `merged` deliverable のタスクが closed になった直後に限り、Master は
+    `git fetch origin <base>` / `git pull --ff-only origin <base>` / `git push origin <base>` を
+    実行してよい（§「Deliverable sync プロトコル」参照）。`push --force` / `reset --hard` 等の
+    破壊的操作は引き続き全面禁止。
 - Conductor / Agent の直接起動・監視・ポーリング・ループ実行
 
 未着手（draft/ready）のタスクを削除するには `cmux-team delete-task --task-id <id> [--journal "理由"]` を使う。
@@ -61,6 +65,8 @@ Master 自身は次の作業を行わない（ユーザーの明示指示があ�
 - Conductor / Agent の直接起動・監視・ポーリング・ループ実行
 - `git push` / `push --force` / `reset --hard` 等、共有状態を書き換える破壊的操作
   （明示指示があっても、実行前に改めてユーザー確認を取る）
+  ※ §「Deliverable sync プロトコル」の例外を除く（merged deliverable closed 直後の
+    `git push origin <base>` のみ許容。`push --force` は引き続き全面禁止）
 - **`abort-task` の安易な使用** — 作業の中断・破棄は最後の手段
 
 ### 判断基準
@@ -175,6 +181,7 @@ cmux-team create-task --title "..." --depends-on "189,190" --status ready
 - 結果の summary.md を読んでから **後続タスクの設計** を決めたいとき
 - 複数タスクの **収束点** で全体状況を再評価したいとき
 - チェーンを組めない（動的に次を決める）一連の作業を見届けたいとき
+- **`merged` deliverable の completion を捕捉し、Master が origin sync (fetch / pull / push) を行うため**（§「Deliverable sync プロトコル」参照）
 
 起動例:
 
@@ -191,6 +198,64 @@ stdout に summary.md の内容、stderr に abort 理由 or 残タスクが出�
 
 **使うべきでない場面:** `depends-on` で済む自動チェーン、ユーザーが即応答を待っている対話の途中、
 排他タスク（`--exclusive`）の drain 待ち（Manager が解決する）。
+
+## Deliverable sync プロトコル
+
+§「`await-task` の使い分け」で示した一般原則の具体適用例。`merged` deliverable で
+完了したタスクの origin sync は **Master の責務**。Conductor / Agent は worktree 内に
+閉じており、`origin/<base>` への push は本来スコープ外。
+
+### deliverable_kind の見極め
+
+- `merged` を選ぶケース: ローカル ff-only マージで完結する（同一リポジトリ・同一 origin）。
+  Master が origin sync を引き受ける前提でのみ採用する。
+- `pr` を選ぶケース: GitHub PR を起票してレビュー / マージは外部に委ねる。
+  origin sync は `gh pr merge` 後に既存ルール（§「やること（追加）」git 同期）で処理。
+- `files` / `none` を選ぶケース: ブランチを残さない納品。sync 不要。
+
+### merged タスクの sync フロー
+
+1. タスクを `--deliverable-kind=merged` 前提で起票・ready 化する。
+2. ready 化と同時に Master ターン上で
+   `Bash(run_in_background=true)` 経由で `cmux-team await-task --task-id N` を起動する。
+3. task-notification を受信したら deliverable で分岐:
+   - `closed (merged)` → 下記「sync 手順」を実行
+   - `closed (pr)` → 何もしない（PR で完結）
+   - `closed (files | none)` → 何もしない
+   - `aborted` → rescue 判断（§「rescue 委譲」）
+
+### sync 手順（closed (merged) のとき）
+
+```bash
+git fetch origin <base>
+git pull --ff-only origin <base>
+git push origin <base>   # 共有ブランチへの push を限定的に許可
+```
+
+- `<base>` はタスクの `merged_into`（= 作業ベースブランチ。通常 mainBranch）。
+- 失敗時（fast-forward 不能 / push reject 等）は **新タスクで rescue 委譲**（§「rescue 委譲」）。
+- Master 自身では破壊的解決をしない（`reset --hard` / `push --force` は禁止継続）。
+
+### 並行 merged の serialize（push 競合対策）
+
+複数の merged タスクが同時 close したとき:
+
+- Master は task-notification を受けた順に **逐次** sync を実行する。
+- 1 件目の `git pull --ff-only && git push` が完了するまで 2 件目の処理に入らない。
+- 実装は「Master の対話ターン上で逐次に処理する」ことで自然に直列化される
+  （1 ターン = 1 sync）。バックグラウンド await-task を複数同時に走らせても、
+  通知受信は Master のメインスレッド上で順番に捌くので push 競合は発生しない。
+
+### rescue 委譲（sync 失敗時 / aborted 時）
+
+直接コンフリクト解消や force push は **行わない**。代わりに後続タスクを起票する:
+
+- title: `"rescue: T{id} merged 後の origin sync"`
+- body: 失敗コマンドの stderr / 直前の HEAD / `merged_into` / `merge_sha` を貼る
+- priority: `high`、status: `ready` で起票し、Conductor (implementer) に解消を委ねる
+
+aborted の場合は原因に応じて (a) 同等の新タスクを起票、(b) ユーザーに判断を仰ぐ、
+のどちらかを選ぶ。
 
 ## 排他タスクの提案
 


### PR DESCRIPTION
## Summary

- issue #45 (Dear で `close-task --deliverable-kind=merged` 後の origin push 不在による diverge 連鎖事故 3 連発) の根治
- 採用方針: **案 D（Master 介在 + `await-task`）**。close-task ハンドラ・FSM は不変更で、Master の責務を文書化する形に統一
- 案 A（close-task 内自動 push）は今回見送り（将来オプションとして余地残し）

## 変更内容

| パス | 概要 |
|---|---|
| `skills/cmux-team/templates/{ja,en}/master.md` | 禁止リストに例外注記 / await-task 用途リスト追加 / 新セクション「Deliverable sync プロトコル」追加 |
| `skills/cmux-team/manager/i18n.ts` | `help_close_task` の merged Examples に NOTE 2 行（en/ja） |
| `README.md` / `README.ja.md` | Communication 表直下に Master responsibilities 段落を新設 |

## 受け入れ基準

- [x] master.md (ja/en) の差分が PR 上で確認できる
- [ ] `cmux-team start` でランタイムプロンプトが再生成され、新セクションが反映される（**PR マージ後に Master 側で実施**）
- [x] close-task --help / README の差分が一貫している
- [ ] Dear リポで軽微なテストタスクを起票し、案 D フローで origin sync が成功するまで動作確認（**PR マージ後の運用検証項目**）
- [x] PR description に issue #45 を `Closes #45` で紐付け

## Test plan

- [x] grep で 4 ファイル × ja/en の追記内容が期待通り
- [x] `bunx tsc --noEmit` が i18n.ts に対してエラーゼロ
- [x] `### ` 見出し数が ja/en master.md で一致 (12 / 12)
- [x] `.team/prompts/master.md` 直接編集なし（テンプレートが Source of Truth ルール遵守）
- [ ] PR マージ後 `cmux-team start` でランタイム再生成して Master ロールに新セクション反映を確認
- [ ] Dear リポで `merged` deliverable タスクを 1 件起票し、Master が await-task → fetch / pull / push の手順を実行できることを確認

## Decision Log（要点）

- **D1**: 「Deliverable sync プロトコル」を §`await-task` 直後 / §排他タスク前に挿入（運用判断の 2 大パターンとして読みやすい位置）
- **D2**: 並行 merged の serialize は文章で説明（Claude のターン直列性に依拠する設計を mutex と誤読されないため）
- **D5**: 案 A（close-task 自動 push）は将来オプションとして余地を残す

## ランタイムプロンプト再生成（マージ後の必須手順）

テンプレート (`templates/{ja,en}/master.md`) はソースオブトゥルース。PR マージ後に Master 側で:

```bash
cmux-team start
# または既に起動中なら Manager を再起動して再生成させる
```

Closes #45